### PR TITLE
docs: add formatting options documentation

### DIFF
--- a/docs/HTML.md
+++ b/docs/HTML.md
@@ -1,0 +1,149 @@
+# HTML Formatting Style
+
+HTML is one of the formatting options supported by Telegram Bot API. It uses
+familiar HTML-like tags for text styling.
+
+## Supported Entities
+
+| Entity            | HTML Syntax                                                               | MessageEntity Type      | FormattedString Method              |
+| ----------------- | ------------------------------------------------------------------------- | ----------------------- | ----------------------------------- |
+| Bold              | `<b>text</b>` or `<strong>text</strong>`                                  | `bold`                  | `bold()`, `b()`                     |
+| Italic            | `<i>text</i>` or `<em>text</em>`                                          | `italic`                | `italic()`, `i()`                   |
+| Underline         | `<u>text</u>` or `<ins>text</ins>`                                        | `underline`             | `underline()`, `u()`                |
+| Strikethrough     | `<s>text</s>`, `<strike>text</strike>`, or `<del>text</del>`              | `strikethrough`         | `strikethrough()`, `s()`            |
+| Spoiler           | `<span class="tg-spoiler">text</span>` or `<tg-spoiler>text</tg-spoiler>` | `spoiler`               | `spoiler()`                         |
+| Inline URL        | `<a href="URL">text</a>`                                                  | `text_link`             | `link(url)`, `a(url)`               |
+| User Mention      | `<a href="tg://user?id=123456">text</a>`                                  | `text_link`             | `mentionUser(text, userId)`         |
+| Custom Emoji      | `<tg-emoji emoji-id="5368324170671202286">emoji</tg-emoji>`               | `text_link`             | `customEmoji(placeholder, emojiId)` |
+| Inline Code       | `<code>code</code>`                                                       | `code`                  | `code()`                            |
+| Pre (Code Block)  | `<pre>code block</pre>`                                                   | `pre`                   | `pre(language)`                     |
+| Pre with Language | `<pre><code class="language-python">code</code></pre>`                    | `pre` + `language`      | `pre(language)`                     |
+| Blockquote        | `<blockquote>quote</blockquote>`                                          | `blockquote`            | `blockquote()`                      |
+| Expandable Quote  | `<blockquote expandable>quote</blockquote>`                               | `expandable_blockquote` | `expandableBlockquote()`            |
+
+## Escaping Rules
+
+Only the following characters need to be escaped in HTML:
+
+| Character | Escape Sequence |
+| --------- | --------------- |
+| `<`       | `&lt;`          |
+| `>`       | `&gt;`          |
+| `&`       | `&amp;`         |
+
+All other HTML entities (like `&nbsp;`, `&copy;`, etc.) are **not** supported.
+
+## Nesting Rules
+
+- **Allowed**: Bold, italic, underline, strikethrough, and spoiler can be nested
+  within each other.
+- **Not allowed**: `<code>` and `<pre>` tags cannot contain any other entities
+  and cannot be nested inside other tags.
+- **Blockquote**: Cannot be nested inside other blockquotes.
+
+## MessageEntity Mapping
+
+When Telegram parses HTML text, it generates `MessageEntity` objects with:
+
+```typescript
+interface MessageEntity {
+  type:
+    | "bold"
+    | "italic"
+    | "underline"
+    | "strikethrough"
+    | "spoiler"
+    | "text_link"
+    | "code"
+    | "pre"
+    | "blockquote"
+    | "expandable_blockquote";
+  offset: number; // UTF-16 code unit offset
+  length: number; // Length in UTF-16 code units
+  url?: string; // For text_link
+  language?: string; // For pre with language
+}
+```
+
+## FormattedString Usage
+
+This library uses `FormattedString` to represent text with entities, bypassing
+the need for HTML parsing entirely:
+
+```typescript
+import { bold, fmt, italic, link } from "@grammyjs/parse-mode";
+
+// Create formatted text using entity tags
+const formatted = fmt`${bold}Hello${bold} ${italic}world${italic}!`;
+
+// Or use static methods
+const greeting = FormattedString.bold("Hello").italic(" world").plain("!");
+
+// Use with grammY
+await ctx.reply(formatted.text, { entities: formatted.entities });
+```
+
+## Advantages of FormattedString over HTML
+
+1. **No escaping required**: Raw text is stored without HTML entity encoding.
+2. **Unicode-safe**: Entity offsets/lengths are calculated automatically.
+3. **Composable**: Combine multiple `FormattedString` instances easily.
+4. **Type-safe**: TypeScript ensures correct entity types.
+5. **No tag matching**: Avoids issues with unclosed or mismatched tags.
+
+## Examples
+
+### HTML Syntax
+
+```html
+<b>bold</b>
+<i>italic</i>
+<u>underline</u>
+<s>strikethrough</s>
+<span class="tg-spoiler">spoiler</span>
+<a href="http://example.com">inline URL</a>
+<code>inline code</code>
+<pre><code class="language-python">code block</code></pre>
+<blockquote>blockquote</blockquote>
+```
+
+### Equivalent FormattedString
+
+```typescript
+import {
+  blockquote,
+  bold,
+  code,
+  fmt,
+  italic,
+  link,
+  pre,
+  spoiler,
+  strikethrough,
+  underline,
+} from "@grammyjs/parse-mode";
+
+const formatted = fmt`
+${bold}bold${bold}
+${italic}italic${italic}
+${underline}underline${underline}
+${strikethrough}strikethrough${strikethrough}
+${spoiler}spoiler${spoiler}
+${link("http://example.com")}inline URL${link}
+${code}inline code${code}
+${pre("python")}code block${pre}
+${blockquote}blockquote${blockquote}
+`;
+```
+
+## Tag Aliases
+
+HTML supports multiple tags for the same entity type:
+
+| Entity        | Primary Tag    | Aliases                     |
+| ------------- | -------------- | --------------------------- |
+| Bold          | `<b>`          | `<strong>`                  |
+| Italic        | `<i>`          | `<em>`                      |
+| Underline     | `<u>`          | `<ins>`                     |
+| Strikethrough | `<s>`          | `<strike>`, `<del>`         |
+| Spoiler       | `<tg-spoiler>` | `<span class="tg-spoiler">` |

--- a/docs/MarkdownV2.md
+++ b/docs/MarkdownV2.md
@@ -1,0 +1,150 @@
+# MarkdownV2 Formatting Style
+
+MarkdownV2 is the recommended Markdown-based formatting option for Telegram Bot
+API. It supports a rich set of text formatting features with strict escaping
+rules.
+
+## Supported Entities
+
+| Entity            | MarkdownV2 Syntax                             | MessageEntity Type      | FormattedString Method              |
+| ----------------- | --------------------------------------------- | ----------------------- | ----------------------------------- |
+| Bold              | `*bold text*`                                 | `bold`                  | `bold()`, `b()`                     |
+| Italic            | `_italic text_`                               | `italic`                | `italic()`, `i()`                   |
+| Underline         | `__underline__`                               | `underline`             | `underline()`, `u()`                |
+| Strikethrough     | `~strikethrough~`                             | `strikethrough`         | `strikethrough()`, `s()`            |
+| Spoiler           | `\|\|spoiler\|\|`                             | `spoiler`               | `spoiler()`                         |
+| Inline URL        | `[text](URL)`                                 | `text_link`             | `link(url)`, `a(url)`               |
+| User Mention      | `[text](tg://user?id=123456)`                 | `text_link`             | `mentionUser(text, userId)`         |
+| Custom Emoji      | `![emoji](tg://emoji?id=5368324170671202286)` | `text_link`             | `customEmoji(placeholder, emojiId)` |
+| Inline Code       | `` `inline code` ``                           | `code`                  | `code()`                            |
+| Pre (Code Block)  | `` ```code block``` ``                        | `pre`                   | `pre(language)`                     |
+| Pre with Language | `` ```python\ncode``` ``                      | `pre` + `language`      | `pre(language)`                     |
+| Blockquote        | `>blockquote`                                 | `blockquote`            | `blockquote()`                      |
+| Expandable Quote  | `**>expandable\n>blockquote`                  | `expandable_blockquote` | `expandableBlockquote()`            |
+
+## Escaping Rules
+
+The following characters must be escaped with a preceding backslash (`\`) in
+MarkdownV2:
+
+```
+_ * [ ] ( ) ~ ` > # + - = | { } . !
+```
+
+Inside `code` and `pre` blocks, only the following need escaping:
+
+```
+` \
+```
+
+Inside inline links `(...)`, only the following need escaping:
+
+```
+) \
+```
+
+## Nesting Rules
+
+- **Allowed**: Bold, italic, underline, strikethrough, and spoiler can be nested
+  within each other.
+- **Not allowed**: `code` and `pre` cannot contain any other entities and cannot
+  be nested inside other entities.
+- **Blockquote**: Cannot be nested inside other blockquotes.
+
+## MessageEntity Mapping
+
+When Telegram parses MarkdownV2 text, it generates `MessageEntity` objects with:
+
+```typescript
+interface MessageEntity {
+  type:
+    | "bold"
+    | "italic"
+    | "underline"
+    | "strikethrough"
+    | "spoiler"
+    | "text_link"
+    | "code"
+    | "pre"
+    | "blockquote"
+    | "expandable_blockquote";
+  offset: number; // UTF-16 code unit offset
+  length: number; // Length in UTF-16 code units
+  url?: string; // For text_link
+  language?: string; // For pre with language
+}
+```
+
+## FormattedString Usage
+
+This library uses `FormattedString` to represent text with entities, bypassing
+the need for MarkdownV2 parsing entirely:
+
+```typescript
+import { bold, fmt, italic, link } from "@grammyjs/parse-mode";
+
+// Create formatted text using entity tags
+const formatted = fmt`${bold}Hello${bold} ${italic}world${italic}!`;
+
+// Or use static methods
+const greeting = FormattedString.bold("Hello").italic(" world").plain("!");
+
+// Use with grammY
+await ctx.reply(formatted.text, { entities: formatted.entities });
+```
+
+## Advantages of FormattedString over MarkdownV2
+
+1. **No escaping required**: Raw text is stored without special character
+   handling.
+2. **Unicode-safe**: Entity offsets/lengths are calculated automatically.
+3. **Composable**: Combine multiple `FormattedString` instances easily.
+4. **Type-safe**: TypeScript ensures correct entity types.
+
+## Examples
+
+### MarkdownV2 Syntax
+
+````
+*bold*
+_italic_
+__underline__
+~strikethrough~
+||spoiler||
+[inline URL](http://example.com)
+`inline code`
+```python
+code block
+````
+
+> blockquote
+
+````
+### Equivalent FormattedString
+
+```typescript
+import {
+  blockquote,
+  bold,
+  code,
+  fmt,
+  italic,
+  link,
+  pre,
+  spoiler,
+  strikethrough,
+  underline,
+} from "@grammyjs/parse-mode";
+
+const formatted = fmt`
+${bold}bold${bold}
+${italic}italic${italic}
+${underline}underline${underline}
+${strikethrough}strikethrough${strikethrough}
+${spoiler}spoiler${spoiler}
+${link("http://example.com")}inline URL${link}
+${code}inline code${code}
+${pre("python")}code block${pre}
+${blockquote}blockquote${blockquote}
+`;
+````

--- a/docs/MessageEntities.md
+++ b/docs/MessageEntities.md
@@ -1,0 +1,218 @@
+# Message Entities Formatting Style
+
+Message Entities is the most powerful and recommended formatting approach for
+Telegram Bot API. Instead of using `parse_mode`, you send plain text along with
+an array of entity objects that define the formatting.
+
+## Supported Entity Types
+
+| Entity Type             | Description                           | FormattedString Method              |
+| ----------------------- | ------------------------------------- | ----------------------------------- |
+| `bold`                  | Bold text                             | `bold()`, `b()`                     |
+| `italic`                | Italic text                           | `italic()`, `i()`                   |
+| `underline`             | Underlined text                       | `underline()`, `u()`                |
+| `strikethrough`         | Strikethrough text                    | `strikethrough()`, `s()`            |
+| `spoiler`               | Spoiler text (hidden until tapped)    | `spoiler()`                         |
+| `text_link`             | Clickable text with URL               | `link(url)`, `a(url)`               |
+| `text_mention`          | Mention without username (by user ID) | `mentionUser(text, userId)`         |
+| `custom_emoji`          | Custom emoji                          | `customEmoji(placeholder, emojiId)` |
+| `code`                  | Inline monospace code                 | `code()`                            |
+| `pre`                   | Code block (with optional language)   | `pre(language)`                     |
+| `blockquote`            | Block quotation                       | `blockquote()`                      |
+| `expandable_blockquote` | Collapsible block quotation           | `expandableBlockquote()`            |
+| `mention`               | @username mention (auto-detected)     | N/A (auto-detected by Telegram)     |
+| `hashtag`               | #hashtag (auto-detected)              | N/A (auto-detected by Telegram)     |
+| `cashtag`               | $USD cashtag (auto-detected)          | N/A (auto-detected by Telegram)     |
+| `bot_command`           | /command (auto-detected)              | N/A (auto-detected by Telegram)     |
+| `url`                   | URL (auto-detected)                   | N/A (auto-detected by Telegram)     |
+| `email`                 | email@example.com (auto-detected)     | N/A (auto-detected by Telegram)     |
+| `phone_number`          | Phone number (auto-detected)          | N/A (auto-detected by Telegram)     |
+
+## MessageEntity Structure
+
+Each entity is defined with the following structure:
+
+```typescript
+interface MessageEntity {
+  type: string; // Entity type from the table above
+  offset: number; // Offset in UTF-16 code units from start of text
+  length: number; // Length in UTF-16 code units
+  url?: string; // For text_link type
+  user?: User; // For text_mention type
+  language?: string; // For pre type with syntax highlighting
+  custom_emoji_id?: string; // For custom_emoji type
+}
+```
+
+## UTF-16 Code Units
+
+**Critical**: Entity `offset` and `length` are measured in **UTF-16 code
+units**, not characters or Unicode code points.
+
+| Character        | Code Points | UTF-16 Code Units |
+| ---------------- | ----------- | ----------------- |
+| ASCII (a-z, 0-9) | 1           | 1                 |
+| Most emoji       | 1           | 2                 |
+| Complex emoji    | Multiple    | 4+                |
+| CJK characters   | 1           | 1                 |
+
+`FormattedString` handles this automatically, but if you build entities
+manually, use JavaScript's string length (which counts UTF-16 code units).
+
+## FormattedString Mapping
+
+This library provides `FormattedString` which generates `MessageEntity` arrays
+automatically:
+
+```typescript
+import { bold, fmt, italic, link } from "@grammyjs/parse-mode";
+
+// Create formatted text using template literals
+const formatted = fmt`${bold}Hello${bold} ${italic}world${italic}!`;
+
+// Access the generated entities
+console.log(formatted.rawText); // "Hello world!"
+console.log(formatted.rawEntities);
+// [
+//   { type: "bold", offset: 0, length: 5 },
+//   { type: "italic", offset: 6, length: 5 }
+// ]
+
+// Use with grammY
+await ctx.reply(formatted.text, { entities: formatted.entities });
+```
+
+## Advantages of Message Entities
+
+1. **No escaping**: Plain text is sent as-is, no special characters to escape.
+2. **Precise control**: Exact offset and length for each entity.
+3. **Unicode-safe**: Works correctly with emoji and international text.
+4. **Composable**: Entities can overlap (where allowed) without parsing issues.
+5. **Future-proof**: New entity types work without parser changes.
+
+## Entity Compatibility Rules
+
+### Can Nest/Overlap
+
+- Bold, italic, underline, strikethrough, spoiler can all nest within each
+  other.
+- Links can contain bold, italic, underline, strikethrough.
+
+### Cannot Nest
+
+- `code` and `pre` cannot contain any other entities.
+- `code` and `pre` cannot be nested inside other entities.
+- `blockquote` and `expandable_blockquote` cannot be nested inside each other.
+
+## FormattedString API
+
+### Entity Tag Functions
+
+```typescript
+import {
+  a,
+  b,
+  blockquote,
+  bold,
+  code,
+  expandableBlockquote,
+  i,
+  italic,
+  link,
+  pre,
+  s,
+  spoiler,
+  strikethrough,
+  u,
+  underline,
+} from "@grammyjs/parse-mode";
+```
+
+### Using fmt Template Literal
+
+```typescript
+// Basic formatting
+const text = fmt`${bold}Bold${bold} and ${italic}italic${italic}`;
+
+// Links
+const linked = fmt`${link("https://example.com")}Click here${link}`;
+
+// Code blocks
+const codeBlock = fmt`${pre("typescript")}const x = 1;${pre}`;
+
+// Nested formatting
+const nested = fmt`${bold}${italic}Bold and italic${italic}${bold}`;
+```
+
+### Using Static Methods
+
+```typescript
+const text = FormattedString.bold("Bold")
+  .plain(" and ")
+  .italic("italic")
+  .plain("!");
+```
+
+### Utility Functions
+
+```typescript
+import { customEmoji, linkMessage, mentionUser } from "@grammyjs/parse-mode";
+
+// Mention a user by ID
+const mention = mentionUser("John", 123456789);
+
+// Link to a message
+const msgLink = linkMessage("See this message", -1001234567890, 42);
+
+// Insert custom emoji
+const emoji = customEmoji("👋", "5368324170671202286");
+```
+
+## Examples
+
+### Building Complex Messages
+
+```typescript
+import { bold, code, fmt, italic, link } from "@grammyjs/parse-mode";
+
+const message = fmt`
+${bold}Welcome to our bot!${bold}
+
+Here are some ${italic}features${italic}:
+• Use ${code}/help${code} to get started
+• Visit our ${link("https://example.com")}website${link}
+`;
+
+await ctx.reply(message.text, { entities: message.entities });
+```
+
+### Joining Multiple FormattedStrings
+
+```typescript
+const parts = [
+  FormattedString.bold("Title"),
+  fmt`${italic}Subtitle${italic}`,
+  "Plain text",
+];
+
+const combined = FormattedString.join(parts, fmt`\n`);
+```
+
+### Splitting Formatted Text
+
+```typescript
+const text = fmt`${bold}Line 1${bold}\n${italic}Line 2${italic}`;
+const lines = text.splitByText(fmt`\n`);
+// Returns array of FormattedString, preserving entities
+```
+
+## Comparison with parse_mode
+
+| Aspect           | parse_mode (HTML/MarkdownV2)       | Message Entities         |
+| ---------------- | ---------------------------------- | ------------------------ |
+| Escaping         | Required for special characters    | Not required             |
+| Unicode handling | Can be tricky with offsets         | Automatic                |
+| Nesting          | Must follow strict syntax rules    | Explicitly defined       |
+| Error handling   | Parse errors possible              | No parsing needed        |
+| Debugging        | Inspect formatted string           | Inspect entity array     |
+| Composability    | String concatenation with escaping | Entity offset adjustment |


### PR DESCRIPTION
Add documentation for each Telegram Bot API formatting style:
- MarkdownV2.md: MarkdownV2 syntax and escaping rules
- HTML.md: HTML tag syntax and entity mappings
- MessageEntities.md: Direct entity usage and advantages

Each document explains the mapping to MessageEntity types and FormattedString methods in this library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide for HTML formatting support, including supported entities, escaping rules, nesting constraints, and usage examples.
  * Added documentation for MarkdownV2 formatting with syntax, escaping rules, entity types, and FormattedString alternative approach.
  * Added documentation for Message Entities formatting approach, covering entity types, structure, utility functions, and integration with grammY.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->