### PR TITLE
Add emoji EntityTag function and FormattedString.emoji methods

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -379,6 +379,7 @@ export class FormattedString
   }
 
   /**
+   * @deprecated Use `emoji` instead
    * Creates a custom emoji formatted string
    * @param placeholder The placeholder emoji text to display
    * @param emoji The custom emoji identifier
@@ -386,6 +387,16 @@ export class FormattedString
    */
   static customEmoji(placeholder: Stringable, emoji: string) {
     return customEmoji(placeholder, emoji);
+  }
+
+  /**
+   * Creates an emoji formatted string using custom emoji
+   * @param text The text content to format with custom emoji
+   * @param customEmojiId The custom emoji ID
+   * @returns A new FormattedString with emoji formatting applied
+   */
+  static emoji(text: Stringable, customEmojiId: string) {
+    return fmt`${emoji(customEmojiId)}${text}${emoji}`;
   }
 
   /**
@@ -675,6 +686,7 @@ export class FormattedString
   }
 
   /**
+   * @deprecated Use `emoji` instead
    * Combines this FormattedString with a custom emoji formatted string
    * @param placeholder The placeholder emoji text to display and append
    * @param emoji The custom emoji identifier
@@ -682,6 +694,16 @@ export class FormattedString
    */
   customEmoji(placeholder: Stringable, emoji: string) {
     return fmt`${this}${FormattedString.customEmoji(placeholder, emoji)}`;
+  }
+
+  /**
+   * Combines this FormattedString with an emoji formatted string using custom emoji
+   * @param text The text content to format with custom emoji and append
+   * @param customEmojiId The custom emoji ID
+   * @returns A new FormattedString combining this instance with emoji formatting
+   */
+  emoji(text: Stringable, customEmojiId: string) {
+    return fmt`${this}${FormattedString.emoji(text, customEmojiId)}`;
   }
 
   /**
@@ -1112,8 +1134,10 @@ export function code() {
  * `pre` entity tag. Cannot be combined with any other formats.
  * @param language The language of the code block.
  */
-export function pre(language: string) {
-  return buildFormatter<[language: string]>("pre", "language")(language);
+export function pre(language?: string) {
+  return buildFormatter<[language: string | undefined]>("pre", "language")(
+    language,
+  );
 }
 
 /**
@@ -1121,6 +1145,17 @@ export function pre(language: string) {
  */
 export function spoiler() {
   return buildFormatter("spoiler")();
+}
+
+/**
+ * `custom_emoji` entity tag. Incompatible with `code` and `pre`.
+ * @param customEmojiId The custom emoji ID.
+ */
+export function emoji(customEmojiId: string) {
+  return buildFormatter<[customEmojiId: string]>(
+    "custom_emoji",
+    "custom_emoji_id",
+  )(customEmojiId);
 }
 
 /**

--- a/test/format.emoji.test.ts
+++ b/test/format.emoji.test.ts
@@ -1,0 +1,47 @@
+import { assertEquals, assertInstanceOf, describe, it } from "./deps.test.ts";
+import { FormattedString } from "../src/format.ts";
+
+describe("FormattedString - emoji formatting methods", () => {
+  it("Static emoji method", () => {
+    const text = "😀";
+    const emojiId = "5123456789123456789";
+
+    const emojiFormatted = FormattedString.emoji(text, emojiId);
+
+    assertInstanceOf(emojiFormatted, FormattedString);
+    assertEquals(emojiFormatted.rawText, text);
+
+    // Test entity properties
+    assertEquals(emojiFormatted.rawEntities.length, 1);
+    assertEquals(emojiFormatted.rawEntities[0]?.type, "custom_emoji");
+    assertEquals(emojiFormatted.rawEntities[0]?.offset, 0);
+    assertEquals(emojiFormatted.rawEntities[0]?.length, text.length);
+    assertEquals(
+      //@ts-expect-error quick test
+      emojiFormatted.rawEntities[0]?.custom_emoji_id,
+      emojiId,
+    );
+  });
+  it("Instance emoji method", () => {
+    const initialText = "Check this out ";
+    const text = "😀";
+    const emojiId = "5123456789123456789";
+    const initialFormatted = new FormattedString(initialText);
+
+    const emojiResult = initialFormatted.emoji(text, emojiId);
+
+    assertInstanceOf(emojiResult, FormattedString);
+    assertEquals(emojiResult.rawText, `${initialText}${text}`);
+
+    // Test entity properties
+    assertEquals(emojiResult.rawEntities.length, 1);
+    assertEquals(emojiResult.rawEntities[0]?.type, "custom_emoji");
+    assertEquals(emojiResult.rawEntities[0]?.offset, initialText.length);
+    assertEquals(emojiResult.rawEntities[0]?.length, text.length);
+    assertEquals(
+      //@ts-expect-error quick test
+      emojiResult.rawEntities[0]?.custom_emoji_id,
+      emojiId,
+    );
+  });
+});


### PR DESCRIPTION
- Add emoji() entity tag function for custom_emoji entities
- Add FormattedString.emoji() static method
- Add FormattedString.prototype.emoji() instance method
- Deprecate customEmoji() methods in favor of emoji()
- Add tests for new emoji methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced emoji formatting: apply custom emojis to specific text and use a standalone emoji helper
  * Preformatted block now accepts an optional language hint for improved code/language rendering

* **Deprecation**
  * Legacy custom-emoji formatting is deprecated; migrate to the new emoji API for ongoing support

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->