### PR TITLE
refactor: Move EntityTag to dedicated file, use new emoji MessageEntity

### DIFF
--- a/src/entity-tag.ts
+++ b/src/entity-tag.ts
@@ -10,9 +10,6 @@ function buildFormatter<T extends Array<unknown> = never>(
   ...formatArgKeys: T
 ): (...formatArgs: T) => EntityTag {
   return (...formatArgs) => {
-    if (type === "pre") {
-      console.log(formatArgs);
-    }
     const formatArgObj = Object.fromEntries(
       formatArgKeys.map((formatArgKey, i) => [formatArgKey, formatArgs[i]]),
     );

--- a/src/entity-tag.ts
+++ b/src/entity-tag.ts
@@ -1,0 +1,133 @@
+import type { MessageEntity } from "./deps.deno.ts";
+
+/**
+ * Represents an entity tag used for formatting text via fmt.
+ */
+export type EntityTag = Omit<MessageEntity, "offset" | "length">;
+
+function buildFormatter<T extends Array<unknown> = never>(
+  type: MessageEntity["type"],
+  ...formatArgKeys: T
+): (...formatArgs: T) => EntityTag {
+  return (...formatArgs) => {
+    if (type === "pre") {
+      console.log(formatArgs);
+    }
+    const formatArgObj = Object.fromEntries(
+      formatArgKeys.map((formatArgKey, i) => [formatArgKey, formatArgs[i]]),
+    );
+    return { type, ...formatArgObj };
+  };
+}
+
+// === Native entity tag functions
+/**
+ * Alias for `bold` entity tag. Incompatible with `code` and `pre`.
+ */
+export function b() {
+  return buildFormatter("bold")();
+}
+/**
+ * `bold` entity tag. Incompatible with `code` and `pre`.
+ */
+export function bold() {
+  return buildFormatter("bold")();
+}
+/**
+ * Alias for `italic` entity tag. Incompatible with `code` and `pre`.
+ */
+export function i() {
+  return buildFormatter("italic")();
+}
+/**
+ * `italic` entity tag. Incompatible with `code` and `pre`.
+ */
+export function italic() {
+  return buildFormatter("italic")();
+}
+/**
+ * Alias for `strikethrough` entity tag. Incompatible with `code` and `pre`.
+ */
+export function s() {
+  return buildFormatter("strikethrough")();
+}
+/**
+ * `strikethrough` entity tag. Incompatible with `code` and `pre`.
+ */
+export function strikethrough() {
+  return buildFormatter("strikethrough")();
+}
+/**
+ * Alias for `underline` entity tag. Incompatible with `code` and `pre`.
+ */
+export function u() {
+  return buildFormatter("underline")();
+}
+/**
+ * `underline` entity tag. Incompatible with `code` and `pre`.
+ */
+export function underline() {
+  return buildFormatter("underline")();
+}
+
+/**
+ * Alias for `link` entity tag. Incompatible with `code` and `pre`.
+ * @param url The URL to link to.
+ */
+export function a(url: string) {
+  return buildFormatter<[url: string]>("text_link", "url")(url);
+}
+/**
+ * `link` entity tag. Incompatible with `code` and `pre`.
+ * @param url The URL to link to.
+ */
+export function link(url: string) {
+  return buildFormatter<[url: string]>("text_link", "url")(url);
+}
+
+/**
+ * `code` entity tag. Cannot be combined with any other formats.
+ */
+export function code() {
+  return buildFormatter("code")();
+}
+/**
+ * `pre` entity tag. Cannot be combined with any other formats.
+ * @param language The language of the code block.
+ */
+export function pre(language?: string) {
+  return buildFormatter<[language: string | undefined]>("pre", "language")(
+    language,
+  );
+}
+
+/**
+ * `spoiler` entity tag. Incompatible with `code` and `pre`.
+ */
+export function spoiler() {
+  return buildFormatter("spoiler")();
+}
+
+/**
+ * `custom_emoji` entity tag. Incompatible with `code` and `pre`.
+ * @param customEmojiId The custom emoji ID.
+ */
+export function emoji(customEmojiId: string) {
+  return buildFormatter<[customEmojiId: string]>(
+    "custom_emoji",
+    "custom_emoji_id",
+  )(customEmojiId);
+}
+
+/**
+ * `blockquote` entity tag. Cannot be nested.
+ */
+export function blockquote() {
+  return buildFormatter("blockquote")();
+}
+/**
+ * `expandable_blockquote` entity tag. Cannot be nested.
+ */
+export function expandableBlockquote() {
+  return buildFormatter("expandable_blockquote")();
+}

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -1,1 +1,2 @@
+export * from "./entity-tag.ts";
 export * from "./format.ts";

--- a/test/format.emoji.test.ts
+++ b/test/format.emoji.test.ts
@@ -1,0 +1,47 @@
+import { assertEquals, assertInstanceOf, describe, it } from "./deps.test.ts";
+import { FormattedString } from "../src/format.ts";
+
+describe("FormattedString - emoji formatting methods", () => {
+  it("Static emoji method", () => {
+    const text = "😀";
+    const emojiId = "5123456789123456789";
+
+    const emojiFormatted = FormattedString.emoji(text, emojiId);
+
+    assertInstanceOf(emojiFormatted, FormattedString);
+    assertEquals(emojiFormatted.rawText, text);
+
+    // Test entity properties
+    assertEquals(emojiFormatted.rawEntities.length, 1);
+    assertEquals(emojiFormatted.rawEntities[0]?.type, "custom_emoji");
+    assertEquals(emojiFormatted.rawEntities[0]?.offset, 0);
+    assertEquals(emojiFormatted.rawEntities[0]?.length, text.length);
+    assertEquals(
+      //@ts-expect-error quick test
+      emojiFormatted.rawEntities[0]?.custom_emoji_id,
+      emojiId,
+    );
+  });
+  it("Instance emoji method", () => {
+    const initialText = "Check this out ";
+    const text = "😀";
+    const emojiId = "5123456789123456789";
+    const initialFormatted = new FormattedString(initialText);
+
+    const emojiResult = initialFormatted.emoji(text, emojiId);
+
+    assertInstanceOf(emojiResult, FormattedString);
+    assertEquals(emojiResult.rawText, `${initialText}${text}`);
+
+    // Test entity properties
+    assertEquals(emojiResult.rawEntities.length, 1);
+    assertEquals(emojiResult.rawEntities[0]?.type, "custom_emoji");
+    assertEquals(emojiResult.rawEntities[0]?.offset, initialText.length);
+    assertEquals(emojiResult.rawEntities[0]?.length, text.length);
+    assertEquals(
+      //@ts-expect-error quick test
+      emojiResult.rawEntities[0]?.custom_emoji_id,
+      emojiId,
+    );
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multiple text formatting options including bold, italic, strikethrough, underline, links, code blocks, spoilers, and blockquotes for enriched message formatting.
  * Introduced custom emoji formatting support for enhanced message decoration.

* **Deprecations**
  * The `customEmoji` method is now deprecated; use the new `emoji` method for custom emoji formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->