### PR TITLE
docs: add documentation for Telegram formatting styles

### DIFF
--- a/docs/html.md
+++ b/docs/html.md
@@ -21,6 +21,8 @@ The following table lists the standard HTML tags and the corresponding `Formatte
 | **User Mention** | `<a href="tg://user?id=123456789">text</a>` | `FormattedString.mentionUser("text", 123456789)` | `mentionUser` (helper) |
 | **Custom Emoji** | `<tg-emoji emoji-id="5368324170671202286">👍</tg-emoji>` | `FormattedString.emoji("👍", "5368324170671202286")` | `emoji` |
 
+> **Note**: The API currently supports only the following named HTML entities: `&lt;`, `&gt;`, `&amp;` and `&quot;`.
+
 ## Usage Example
 
 ```typescript
@@ -31,7 +33,3 @@ import { fmt, bold, italic, link } from "@grammyjs/parse-mode";
 // but primarily sends entities directly to Telegram.
 const message = fmt`${bold("Hello")} <i>World</i>`;
 ```
-
-## Escaping
-
-When using `fmt` or `FormattedString`, the library handles necessary escaping automatically. You do not need to manually escape characters like `<`, `>`, `&`.

--- a/docs/html.md
+++ b/docs/html.md
@@ -1,0 +1,37 @@
+# HTML Style
+
+This document describes the **HTML** formatting style supported by the Telegram Bot API and how it maps to the `@grammyjs/parse-mode` library.
+
+## Supported Entities
+
+The following table lists the standard HTML tags and the corresponding `FormattedString` methods and `fmt` template tags in this library.
+
+| Feature | HTML Syntax | Library Method | Template Tag |
+| :--- | :--- | :--- | :--- |
+| **Bold** | `<b>bold</b>`, `<strong>bold</strong>` | `FormattedString.bold("text")` | `bold`, `b` |
+| **Italic** | `<i>italic</i>`, `<em>italic</em>` | `FormattedString.italic("text")` | `italic`, `i` |
+| **Underline** | `<u>underline</u>`, `<ins>underline</ins>` | `FormattedString.underline("text")` | `underline`, `u` |
+| **Strikethrough** | `<s>strike</s>`, `<strike>strike</strike>`, `<del>strike</del>` | `FormattedString.strikethrough("text")` | `strikethrough`, `s` |
+| **Spoiler** | `<span class="tg-spoiler">spoiler</span>`, `<tg-spoiler>spoiler</tg-spoiler>` | `FormattedString.spoiler("text")` | `spoiler` |
+| **Link** | `<a href="http://www.example.com/">text</a>` | `FormattedString.link("text", "url")` | `link`, `a` |
+| **Inline Code** | `<code>inline code</code>` | `FormattedString.code("text")` | `code` |
+| **Code Block** | `<pre><code class="language-python">print("hello")</code></pre>` | `FormattedString.pre("text", "language")` | `pre` |
+| **Blockquote** | `<blockquote>block quote</blockquote>` | `FormattedString.blockquote("text")` | `blockquote` |
+| **Expandable Blockquote** | `<blockquote expandable>expandable block quote</blockquote>` | `FormattedString.expandableBlockquote("text")` | `expandableBlockquote` |
+| **User Mention** | `<a href="tg://user?id=123456789">text</a>` | `FormattedString.mentionUser("text", 123456789)` | `mentionUser` (helper) |
+| **Custom Emoji** | `<tg-emoji emoji-id="5368324170671202286">👍</tg-emoji>` | `FormattedString.emoji("👍", "5368324170671202286")` | `emoji` |
+
+## Usage Example
+
+```typescript
+import { fmt, bold, italic, link } from "@grammyjs/parse-mode";
+
+// The library generates the underlying entity structure, 
+// which can then be serialized to HTML if needed, 
+// but primarily sends entities directly to Telegram.
+const message = fmt`${bold("Hello")} <i>World</i>`;
+```
+
+## Escaping
+
+When using `fmt` or `FormattedString`, the library handles necessary escaping automatically. You do not need to manually escape characters like `<`, `>`, `&`.

--- a/docs/html.md
+++ b/docs/html.md
@@ -21,7 +21,7 @@ The following table lists the standard HTML tags and the corresponding `Formatte
 | **User Mention** | `<a href="tg://user?id=123456789">text</a>` | `FormattedString.mentionUser("text", 123456789)` | `mentionUser` (helper) |
 | **Custom Emoji** | `<tg-emoji emoji-id="5368324170671202286">👍</tg-emoji>` | `FormattedString.emoji("👍", "5368324170671202286")` | `emoji` |
 
-> **Note**: The API currently supports only the following named HTML entities: `&lt;`, `&gt;`, `&amp;` and `&quot;`.
+> **Note**: The API currently supports only the following named HTML entities: `&lt;`, `&gt;`, `&amp;` and `&quot;`. All numerical HTML entities are supported.
 
 ## Usage Example
 

--- a/docs/markdown-v2.md
+++ b/docs/markdown-v2.md
@@ -1,0 +1,45 @@
+# MarkdownV2 Style
+
+This document describes the **MarkdownV2** formatting style supported by the Telegram Bot API and how it maps to the `@grammyjs/parse-mode` library.
+
+## Supported Entities
+
+The following table lists the standard MarkdownV2 syntax and the corresponding `FormattedString` methods and `fmt` template tags in this library.
+
+| Feature | MarkdownV2 Syntax | Library Method | Template Tag |
+| :--- | :--- | :--- | :--- |
+| **Bold** | `*bold text*` | `FormattedString.bold("text")` | `bold`, `b` |
+| **Italic** | `_italic text_` | `FormattedString.italic("text")` | `italic`, `i` |
+| **Underline** | `__underline__` | `FormattedString.underline("text")` | `underline`, `u` |
+| **Strikethrough** | `~strikethrough~` | `FormattedString.strikethrough("text")` | `strikethrough`, `s` |
+| **Spoiler** | `||spoiler||` | `FormattedString.spoiler("text")` | `spoiler` |
+| **Link** | `[text](http://www.example.com/)` | `FormattedString.link("text", "url")` | `link`, `a` |
+| **Inline Code** | `` `inline code` `` | `FormattedString.code("text")` | `code` |
+| **Code Block** | ```` ```python\nprint("hello")\n``` ```` | `FormattedString.pre("text", "language")` | `pre` |
+| **Blockquote** | `>block quote` | `FormattedString.blockquote("text")` | `blockquote` |
+| **Expandable Blockquote** | `**>expandable block quote` | `FormattedString.expandableBlockquote("text")` | `expandableBlockquote` |
+| **User Mention** | `[text](tg://user?id=123456789)` | `FormattedString.mentionUser("text", 123456789)` | `mentionUser` (helper) |
+| **Custom Emoji** | `![👍](tg://emoji?id=5368324170671202286)` | `FormattedString.emoji("👍", "5368324170671202286")` | `emoji` |
+
+## Usage Example
+
+```typescript
+import { fmt, bold, italic, link } from "@grammyjs/parse-mode";
+
+// Using the fmt template literal (Recommended)
+const message = fmt`${bold("Welcome!")}
+Check out our ${link("website", "https://grammy.dev")}.
+${italic("Note: This uses MarkdownV2 style internaly.")}`;
+
+// Using the Fluent API
+const message2 = new FormattedString("Welcome!")
+  .bold()
+  .append("\nCheck out our ")
+  .append(new FormattedString("website").link("https://grammy.dev"));
+```
+
+## Escaping
+
+When using `fmt` or `FormattedString`, the library handles all necessary escaping for MarkdownV2 automatically. You do not need to manually escape special characters like `_`, `*`, `[`, `]`, `(`, `)`, `~`, `>`, `#`, `+`, `-`, `=`, `|`, `{`, `}`, `.`, `!`. 
+
+```

--- a/docs/markdown-v2.md
+++ b/docs/markdown-v2.md
@@ -38,8 +38,4 @@ const message2 = new FormattedString("Welcome!")
   .append(new FormattedString("website").link("https://grammy.dev"));
 ```
 
-## Escaping
-
-When using `fmt` or `FormattedString`, the library handles all necessary escaping for MarkdownV2 automatically. You do not need to manually escape special characters like `_`, `*`, `[`, `]`, `(`, `)`, `~`, `>`, `#`, `+`, `-`, `=`, `|`, `{`, `}`, `.`, `!`. 
-
 ```

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -1,0 +1,36 @@
+# Markdown Style (Legacy)
+
+This document describes the legacy **Markdown** formatting style supported by the Telegram Bot API and how it maps to the `@grammyjs/parse-mode` library.
+
+> **Note:** This style is legacy and has limited support. It is recommended to use **MarkdownV2** or **HTML** for new bots.
+
+## Supported Entities
+
+The following table lists the standard Markdown (legacy) syntax and the corresponding `FormattedString` methods and `fmt` template tags in this library.
+
+| Feature | Markdown Syntax | Library Method | Template Tag |
+| :--- | :--- | :--- | :--- |
+| **Bold** | `*bold text*` | `FormattedString.bold("text")` | `bold`, `b` |
+| **Italic** | `_italic text_` | `FormattedString.italic("text")` | `italic`, `i` |
+| **Link** | `[text](http://www.example.com/)` | `FormattedString.link("text", "url")` | `link`, `a` |
+| **Inline Code** | `` `inline code` `` | `FormattedString.code("text")` | `code` |
+| **Code Block** | ```` ```pre``` ```` | `FormattedString.pre("text", "")` | `pre` (no language) |
+| **User Mention** | `[text](tg://user?id=123456789)` | `FormattedString.mentionUser("text", 123456789)` | `mentionUser` (helper) |
+
+## Limitations
+
+Legacy Markdown does **not** support:
+- Underline
+- Strikethrough
+- Spoilers
+- Custom Emoji
+- Nested entities
+- Escaping inside entities in some cases
+
+## Usage Example
+
+```typescript
+import { fmt, bold, italic } from "@grammyjs/parse-mode";
+
+const message = fmt`${bold("Bold")} and ${italic("Italic")}`;
+```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added HTML formatting guide with supported entities and usage examples.
  * Added MarkdownV2 formatting reference with syntax mappings and implementation examples.
  * Added legacy Markdown formatting documentation with limitations and recommendations for modern alternatives.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->