### PR TITLE
docs: add formatting options documentation

### DIFF
--- a/docs/HTML.md
+++ b/docs/HTML.md
@@ -60,13 +60,13 @@ All other HTML entities (numeric or named) are supported.
 import { fmt, bold, FormattedString } from "@grammyjs/parse-mode";
 
 // Using entity tag
-const result = fmt`${bold}bold text${bold}`;
+const fromFmt = fmt`${bold}bold text${bold}`;
 
 // Using static method
-const result = FormattedString.bold("bold text");
+const fromStatic = FormattedString.bold("bold text");
 
-// Using instance method (alias)
-const result = FormattedString.b("bold text");
+// Using static method (alias)
+const fromAlias = FormattedString.b("bold text");
 ```
 
 ---
@@ -88,9 +88,9 @@ const result = FormattedString.b("bold text");
 ```typescript
 import { fmt, italic, FormattedString } from "@grammyjs/parse-mode";
 
-const result = fmt`${italic}italic text${italic}`;
-const result = FormattedString.italic("italic text");
-const result = FormattedString.i("italic text"); // alias
+const fromFmt = fmt`${italic}italic text${italic}`;
+const fromStatic = FormattedString.italic("italic text");
+const fromAlias = FormattedString.i("italic text"); // alias
 ```
 
 ---
@@ -112,9 +112,9 @@ const result = FormattedString.i("italic text"); // alias
 ```typescript
 import { fmt, underline, FormattedString } from "@grammyjs/parse-mode";
 
-const result = fmt`${underline}underline text${underline}`;
-const result = FormattedString.underline("underline text");
-const result = FormattedString.u("underline text"); // alias
+const fromFmt = fmt`${underline}underline text${underline}`;
+const fromStatic = FormattedString.underline("underline text");
+const fromAlias = FormattedString.u("underline text"); // alias
 ```
 
 ---
@@ -137,9 +137,9 @@ const result = FormattedString.u("underline text"); // alias
 ```typescript
 import { fmt, strikethrough, FormattedString } from "@grammyjs/parse-mode";
 
-const result = fmt`${strikethrough}strikethrough text${strikethrough}`;
-const result = FormattedString.strikethrough("strikethrough text");
-const result = FormattedString.s("strikethrough text"); // alias
+const fromFmt = fmt`${strikethrough}strikethrough text${strikethrough}`;
+const fromStatic = FormattedString.strikethrough("strikethrough text");
+const fromAlias = FormattedString.s("strikethrough text"); // alias
 ```
 
 ---
@@ -161,8 +161,8 @@ const result = FormattedString.s("strikethrough text"); // alias
 ```typescript
 import { fmt, spoiler, FormattedString } from "@grammyjs/parse-mode";
 
-const result = fmt`${spoiler}spoiler text${spoiler}`;
-const result = FormattedString.spoiler("spoiler text");
+const fromFmt = fmt`${spoiler}spoiler text${spoiler}`;
+const fromStatic = FormattedString.spoiler("spoiler text");
 ```
 
 ---
@@ -183,8 +183,8 @@ const result = FormattedString.spoiler("spoiler text");
 ```typescript
 import { fmt, code, FormattedString } from "@grammyjs/parse-mode";
 
-const result = fmt`${code}inline code${code}`;
-const result = FormattedString.code("inline code");
+const fromFmt = fmt`${code}inline code${code}`;
+const fromStatic = FormattedString.code("inline code");
 ```
 
 > **Note:** Code entities cannot be combined with other formatting (bold, italic, etc.).
@@ -214,11 +214,11 @@ const result = FormattedString.code("inline code");
 import { fmt, pre, FormattedString } from "@grammyjs/parse-mode";
 
 // Without language
-const result = fmt`${pre()}pre-formatted code${pre}`;
+const fromFmt = fmt`${pre()}pre-formatted code${pre}`;
 
 // With language
-const result = fmt`${pre("python")}print("Hello")${pre}`;
-const result = FormattedString.pre('print("Hello")', "python");
+const fromFmtLang = fmt`${pre("python")}print("Hello")${pre}`;
+const fromStatic = FormattedString.pre('print("Hello")', "python");
 ```
 
 > **Note:** Pre entities cannot be combined with other formatting.
@@ -241,9 +241,9 @@ const result = FormattedString.pre('print("Hello")', "python");
 ```typescript
 import { fmt, link, FormattedString } from "@grammyjs/parse-mode";
 
-const result = fmt`${link("https://example.com")}link text${link}`;
-const result = FormattedString.link("link text", "https://example.com");
-const result = FormattedString.a("link text", "https://example.com"); // alias
+const fromFmt = fmt`${link("https://example.com")}link text${link}`;
+const fromStatic = FormattedString.link("link text", "https://example.com");
+const fromAlias = FormattedString.a("link text", "https://example.com"); // alias
 ```
 
 ---
@@ -264,8 +264,8 @@ const result = FormattedString.a("link text", "https://example.com"); // alias
 ```typescript
 import { FormattedString, mentionUser } from "@grammyjs/parse-mode";
 
-const result = mentionUser("user name", 123456789);
-const result = FormattedString.mentionUser("user name", 123456789);
+const fromFunc = mentionUser("user name", 123456789);
+const fromStatic = FormattedString.mentionUser("user name", 123456789);
 ```
 
 ---
@@ -286,8 +286,8 @@ const result = FormattedString.mentionUser("user name", 123456789);
 ```typescript
 import { fmt, emoji, FormattedString } from "@grammyjs/parse-mode";
 
-const result = fmt`${emoji("5368324170671202286")}👍${emoji}`;
-const result = FormattedString.emoji("👍", "5368324170671202286");
+const fromFmt = fmt`${emoji("5368324170671202286")}👍${emoji}`;
+const fromStatic = FormattedString.emoji("👍", "5368324170671202286");
 ```
 
 ---
@@ -308,8 +308,8 @@ const result = FormattedString.emoji("👍", "5368324170671202286");
 ```typescript
 import { fmt, blockquote, FormattedString } from "@grammyjs/parse-mode";
 
-const result = fmt`${blockquote}Block quotation text${blockquote}`;
-const result = FormattedString.blockquote("Block quotation text");
+const fromFmt = fmt`${blockquote}Block quotation text${blockquote}`;
+const fromStatic = FormattedString.blockquote("Block quotation text");
 ```
 
 ---
@@ -330,8 +330,8 @@ const result = FormattedString.blockquote("Block quotation text");
 ```typescript
 import { fmt, expandableBlockquote, FormattedString } from "@grammyjs/parse-mode";
 
-const result = fmt`${expandableBlockquote}Expandable quotation${expandableBlockquote}`;
-const result = FormattedString.expandableBlockquote("Expandable quotation");
+const fromFmt = fmt`${expandableBlockquote}Expandable quotation text${expandableBlockquote}`;
+const fromStatic = FormattedString.expandableBlockquote("Expandable quotation text");
 ```
 
 ---
@@ -355,10 +355,10 @@ HTML supports rich nesting of formatting elements:
 import { fmt, bold, italic, underline } from "@grammyjs/parse-mode";
 
 // Bold italic text
-const result = fmt`${bold}${italic}bold and italic${italic}${bold}`;
+const boldItalic = fmt`${bold}${italic}bold and italic${italic}${bold}`;
 
 // Underlined bold text
-const result = fmt`${underline}${bold}underlined bold${bold}${underline}`;
+const underlinedBold = fmt`${underline}${bold}underlined bold${bold}${underline}`;
 ```
 
 ---

--- a/docs/HTML.md
+++ b/docs/HTML.md
@@ -1,0 +1,373 @@
+# HTML Formatting
+
+This document describes the HTML formatting style supported by the Telegram Bot API and how each HTML element maps to `MessageEntity` types and `FormattedString` methods in this library.
+
+## Overview
+
+HTML is a flexible formatting mode that uses familiar HTML tags. It's often easier to work with than MarkdownV2 because it doesn't require escaping as many special characters.
+
+### Special Characters
+
+The following characters must be replaced with HTML entities:
+
+| Character | HTML Entity |
+|-----------|-------------|
+| `<` | `&lt;` |
+| `>` | `&gt;` |
+| `&` | `&amp;` |
+
+All other HTML entities (numeric or named) are supported.
+
+---
+
+## Entity Reference
+
+| HTML Tag | MessageEntity Type | FormattedString Method |
+|----------|-------------------|----------------------|
+| `<b>`, `<strong>` | `bold` | `FormattedString.bold()` or `fmt\`${bold}...\`` |
+| `<i>`, `<em>` | `italic` | `FormattedString.italic()` or `fmt\`${italic}...\`` |
+| `<u>`, `<ins>` | `underline` | `FormattedString.underline()` or `fmt\`${underline}...\`` |
+| `<s>`, `<strike>`, `<del>` | `strikethrough` | `FormattedString.strikethrough()` or `fmt\`${strikethrough}...\`` |
+| `<span class="tg-spoiler">`, `<tg-spoiler>` | `spoiler` | `FormattedString.spoiler()` or `fmt\`${spoiler}...\`` |
+| `<code>` | `code` | `FormattedString.code()` or `fmt\`${code}...\`` |
+| `<pre>` | `pre` | `FormattedString.pre()` or `fmt\`${pre()}...\`` |
+| `<pre><code class="language-xxx">` | `pre` (with `language`) | `FormattedString.pre(text, "xxx")` |
+| `<a href="url">` | `text_link` | `FormattedString.link(text, url)` |
+| `<a href="tg://user?id=123">` | `text_link` | `FormattedString.mentionUser(text, userId)` |
+| `<tg-emoji emoji-id="123">` | `custom_emoji` | `FormattedString.emoji(text, emojiId)` |
+| `<blockquote>` | `blockquote` | `FormattedString.blockquote()` |
+| `<blockquote expandable>` | `expandable_blockquote` | `FormattedString.expandableBlockquote()` |
+
+---
+
+## Detailed Entity Descriptions
+
+### Bold
+
+**HTML Syntax:**
+```html
+<b>bold text</b>
+<strong>bold text</strong>
+```
+
+**MessageEntity:**
+```json
+{ "type": "bold", "offset": 0, "length": 9 }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, bold, FormattedString } from "@grammyjs/parse-mode";
+
+// Using entity tag
+const result = fmt`${bold}bold text${bold}`;
+
+// Using static method
+const result = FormattedString.bold("bold text");
+
+// Using instance method (alias)
+const result = FormattedString.b("bold text");
+```
+
+---
+
+### Italic
+
+**HTML Syntax:**
+```html
+<i>italic text</i>
+<em>italic text</em>
+```
+
+**MessageEntity:**
+```json
+{ "type": "italic", "offset": 0, "length": 11 }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, italic, FormattedString } from "@grammyjs/parse-mode";
+
+const result = fmt`${italic}italic text${italic}`;
+const result = FormattedString.italic("italic text");
+const result = FormattedString.i("italic text"); // alias
+```
+
+---
+
+### Underline
+
+**HTML Syntax:**
+```html
+<u>underline text</u>
+<ins>underline text</ins>
+```
+
+**MessageEntity:**
+```json
+{ "type": "underline", "offset": 0, "length": 14 }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, underline, FormattedString } from "@grammyjs/parse-mode";
+
+const result = fmt`${underline}underline text${underline}`;
+const result = FormattedString.underline("underline text");
+const result = FormattedString.u("underline text"); // alias
+```
+
+---
+
+### Strikethrough
+
+**HTML Syntax:**
+```html
+<s>strikethrough text</s>
+<strike>strikethrough text</strike>
+<del>strikethrough text</del>
+```
+
+**MessageEntity:**
+```json
+{ "type": "strikethrough", "offset": 0, "length": 18 }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, strikethrough, FormattedString } from "@grammyjs/parse-mode";
+
+const result = fmt`${strikethrough}strikethrough text${strikethrough}`;
+const result = FormattedString.strikethrough("strikethrough text");
+const result = FormattedString.s("strikethrough text"); // alias
+```
+
+---
+
+### Spoiler
+
+**HTML Syntax:**
+```html
+<span class="tg-spoiler">spoiler text</span>
+<tg-spoiler>spoiler text</tg-spoiler>
+```
+
+**MessageEntity:**
+```json
+{ "type": "spoiler", "offset": 0, "length": 12 }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, spoiler, FormattedString } from "@grammyjs/parse-mode";
+
+const result = fmt`${spoiler}spoiler text${spoiler}`;
+const result = FormattedString.spoiler("spoiler text");
+```
+
+---
+
+### Inline Code
+
+**HTML Syntax:**
+```html
+<code>inline code</code>
+```
+
+**MessageEntity:**
+```json
+{ "type": "code", "offset": 0, "length": 11 }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, code, FormattedString } from "@grammyjs/parse-mode";
+
+const result = fmt`${code}inline code${code}`;
+const result = FormattedString.code("inline code");
+```
+
+> **Note:** Code entities cannot be combined with other formatting (bold, italic, etc.).
+
+---
+
+### Pre-formatted Code Block
+
+**HTML Syntax (without language):**
+```html
+<pre>pre-formatted code</pre>
+```
+
+**HTML Syntax (with language):**
+```html
+<pre><code class="language-python">print("Hello")</code></pre>
+```
+
+**MessageEntity:**
+```json
+{ "type": "pre", "offset": 0, "length": 18 }
+{ "type": "pre", "offset": 0, "length": 14, "language": "python" }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, pre, FormattedString } from "@grammyjs/parse-mode";
+
+// Without language
+const result = fmt`${pre()}pre-formatted code${pre}`;
+
+// With language
+const result = fmt`${pre("python")}print("Hello")${pre}`;
+const result = FormattedString.pre('print("Hello")', "python");
+```
+
+> **Note:** Pre entities cannot be combined with other formatting.
+
+---
+
+### Text Link
+
+**HTML Syntax:**
+```html
+<a href="https://example.com">link text</a>
+```
+
+**MessageEntity:**
+```json
+{ "type": "text_link", "offset": 0, "length": 9, "url": "https://example.com" }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, link, FormattedString } from "@grammyjs/parse-mode";
+
+const result = fmt`${link("https://example.com")}link text${link}`;
+const result = FormattedString.link("link text", "https://example.com");
+const result = FormattedString.a("link text", "https://example.com"); // alias
+```
+
+---
+
+### User Mention (Text Mention)
+
+**HTML Syntax:**
+```html
+<a href="tg://user?id=123456789">user name</a>
+```
+
+**MessageEntity:**
+```json
+{ "type": "text_link", "offset": 0, "length": 9, "url": "tg://user?id=123456789" }
+```
+
+**FormattedString Usage:**
+```typescript
+import { FormattedString, mentionUser } from "@grammyjs/parse-mode";
+
+const result = mentionUser("user name", 123456789);
+const result = FormattedString.mentionUser("user name", 123456789);
+```
+
+---
+
+### Custom Emoji
+
+**HTML Syntax:**
+```html
+<tg-emoji emoji-id="5368324170671202286">👍</tg-emoji>
+```
+
+**MessageEntity:**
+```json
+{ "type": "custom_emoji", "offset": 0, "length": 2, "custom_emoji_id": "5368324170671202286" }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, emoji, FormattedString } from "@grammyjs/parse-mode";
+
+const result = fmt`${emoji("5368324170671202286")}👍${emoji}`;
+const result = FormattedString.emoji("👍", "5368324170671202286");
+```
+
+---
+
+### Blockquote
+
+**HTML Syntax:**
+```html
+<blockquote>Block quotation text</blockquote>
+```
+
+**MessageEntity:**
+```json
+{ "type": "blockquote", "offset": 0, "length": 20 }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, blockquote, FormattedString } from "@grammyjs/parse-mode";
+
+const result = fmt`${blockquote}Block quotation text${blockquote}`;
+const result = FormattedString.blockquote("Block quotation text");
+```
+
+---
+
+### Expandable Blockquote
+
+**HTML Syntax:**
+```html
+<blockquote expandable>Expandable quotation text</blockquote>
+```
+
+**MessageEntity:**
+```json
+{ "type": "expandable_blockquote", "offset": 0, "length": 25 }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, expandableBlockquote, FormattedString } from "@grammyjs/parse-mode";
+
+const result = fmt`${expandableBlockquote}Expandable quotation${expandableBlockquote}`;
+const result = FormattedString.expandableBlockquote("Expandable quotation");
+```
+
+---
+
+## Nesting Rules
+
+HTML supports rich nesting of formatting elements:
+
+- **Allowed nesting:** `<b>`, `<i>`, `<u>`, `<s>`, `<span class="tg-spoiler">`, and `<a>` can be nested within each other
+- **Cannot nest:** `<code>` and `<pre>` elements cannot contain or be contained by other formatting
+- **Blockquotes:** Can contain other formatting but cannot be nested within other blockquotes
+
+### Example: Nested Formatting
+
+```html
+<b><i>bold and italic</i></b>
+<u><b>underlined bold</b></u>
+```
+
+```typescript
+import { fmt, bold, italic, underline } from "@grammyjs/parse-mode";
+
+// Bold italic text
+const result = fmt`${bold}${italic}bold and italic${italic}${bold}`;
+
+// Underlined bold text
+const result = fmt`${underline}${bold}underlined bold${bold}${underline}`;
+```
+
+---
+
+## Unsupported HTML
+
+Only the tags listed above are supported. All other HTML tags will be ignored or may cause parsing errors:
+
+- No support for `<br>`, `<p>`, `<div>`, `<span>` (except with `tg-spoiler` class)
+- No support for CSS styling via `style` attribute
+- No support for `<img>`, `<video>`, or other media tags
+- Attributes other than those specified above are ignored

--- a/docs/Markdown.md
+++ b/docs/Markdown.md
@@ -1,0 +1,262 @@
+# Markdown (Legacy) Formatting
+
+This document describes the legacy Markdown formatting style supported by the Telegram Bot API and how each syntax element maps to `MessageEntity` types and `FormattedString` methods in this library.
+
+## ⚠️ Deprecation Notice
+
+**Markdown mode is considered legacy.** Telegram recommends using **MarkdownV2** or **HTML** instead for new bots. The legacy Markdown mode has limited formatting options and can be error-prone due to parsing ambiguities.
+
+---
+
+## Overview
+
+The legacy Markdown mode provides basic text formatting with a simplified syntax. It supports fewer formatting options than MarkdownV2 and has different escaping rules.
+
+### Special Characters
+
+The following characters have special meaning and may need escaping:
+- `_` (underscore) - italic
+- `*` (asterisk) - bold
+- `` ` `` (backtick) - code
+- `[` and `]` - links
+
+Use `\` to escape these characters when you want them as literal text.
+
+---
+
+## Entity Reference
+
+| Syntax | Example | MessageEntity Type | FormattedString Method |
+|--------|---------|-------------------|----------------------|
+| `*bold*` | *bold* | `bold` | `FormattedString.bold()` or `fmt\`${bold}...\`` |
+| `_italic_` | _italic_ | `italic` | `FormattedString.italic()` or `fmt\`${italic}...\`` |
+| `` `code` `` | `code` | `code` | `FormattedString.code()` or `fmt\`${code}...\`` |
+| ` ```pre``` ` | pre block | `pre` | `FormattedString.pre()` or `fmt\`${pre()}...\`` |
+| `[text](url)` | [link](url) | `text_link` | `FormattedString.link(text, url)` |
+| `[text](tg://user?id=123)` | user mention | `text_link` | `FormattedString.mentionUser(text, userId)` |
+
+### Not Supported in Legacy Markdown
+
+The following formatting options are **NOT available** in legacy Markdown mode:
+
+| Feature | MessageEntity Type | Available in |
+|---------|-------------------|--------------|
+| Underline | `underline` | MarkdownV2, HTML |
+| Strikethrough | `strikethrough` | MarkdownV2, HTML |
+| Spoiler | `spoiler` | MarkdownV2, HTML |
+| Custom Emoji | `custom_emoji` | MarkdownV2, HTML |
+| Blockquote | `blockquote` | MarkdownV2, HTML |
+| Expandable Blockquote | `expandable_blockquote` | MarkdownV2, HTML |
+| Code with Language | `pre` with `language` | MarkdownV2, HTML |
+
+---
+
+## Detailed Entity Descriptions
+
+### Bold
+
+**Syntax:** `*bold text*`
+
+**MessageEntity:**
+```json
+{ "type": "bold", "offset": 0, "length": 9 }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, bold, FormattedString } from "@grammyjs/parse-mode";
+
+// Using entity tag
+const result = fmt`${bold}bold text${bold}`;
+
+// Using static method
+const result = FormattedString.bold("bold text");
+
+// Using instance method
+const result = FormattedString.b("bold text"); // alias
+```
+
+---
+
+### Italic
+
+**Syntax:** `_italic text_`
+
+**MessageEntity:**
+```json
+{ "type": "italic", "offset": 0, "length": 11 }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, italic, FormattedString } from "@grammyjs/parse-mode";
+
+const result = fmt`${italic}italic text${italic}`;
+const result = FormattedString.italic("italic text");
+const result = FormattedString.i("italic text"); // alias
+```
+
+---
+
+### Inline Code
+
+**Syntax:** `` `inline code` ``
+
+**MessageEntity:**
+```json
+{ "type": "code", "offset": 0, "length": 11 }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, code, FormattedString } from "@grammyjs/parse-mode";
+
+const result = fmt`${code}inline code${code}`;
+const result = FormattedString.code("inline code");
+```
+
+> **Note:** Code entities cannot be combined with other formatting.
+
+---
+
+### Pre-formatted Code Block
+
+**Syntax:**
+````
+```
+pre-formatted code
+```
+````
+
+**MessageEntity:**
+```json
+{ "type": "pre", "offset": 0, "length": 18 }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, pre, FormattedString } from "@grammyjs/parse-mode";
+
+const result = fmt`${pre()}pre-formatted code${pre}`;
+```
+
+> **Note:** Legacy Markdown does **not** support language specification in code blocks. Use MarkdownV2 or HTML if you need syntax highlighting.
+
+---
+
+### Text Link
+
+**Syntax:** `[link text](https://example.com)`
+
+**MessageEntity:**
+```json
+{ "type": "text_link", "offset": 0, "length": 9, "url": "https://example.com" }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, link, FormattedString } from "@grammyjs/parse-mode";
+
+const result = fmt`${link("https://example.com")}link text${link}`;
+const result = FormattedString.link("link text", "https://example.com");
+const result = FormattedString.a("link text", "https://example.com"); // alias
+```
+
+---
+
+### User Mention (Text Mention)
+
+**Syntax:** `[user name](tg://user?id=123456789)`
+
+**MessageEntity:**
+```json
+{ "type": "text_link", "offset": 0, "length": 9, "url": "tg://user?id=123456789" }
+```
+
+**FormattedString Usage:**
+```typescript
+import { FormattedString, mentionUser } from "@grammyjs/parse-mode";
+
+const result = mentionUser("user name", 123456789);
+const result = FormattedString.mentionUser("user name", 123456789);
+```
+
+---
+
+## Limitations and Gotchas
+
+### No Nesting Support
+
+Legacy Markdown has **very limited nesting support**:
+
+- You cannot reliably nest bold inside italic or vice versa
+- Combining `*` and `_` in complex ways often leads to parsing errors
+
+**Example of problematic syntax:**
+```
+*_bold italic_* ← May not parse correctly
+```
+
+### Escaping Issues
+
+The legacy parser can be finicky about special characters:
+
+- Unmatched `*` or `_` characters may cause the entire message to fail parsing
+- Using `\` to escape doesn't always work as expected
+
+### Recommendation
+
+**Use MarkdownV2 or HTML instead.** They offer:
+
+1. More formatting options (underline, strikethrough, spoiler, etc.)
+2. Better nesting support
+3. More predictable escaping behavior
+4. Syntax highlighting for code blocks
+
+---
+
+## Migration to MarkdownV2
+
+If you're using legacy Markdown, here's how to migrate:
+
+| Legacy Markdown | MarkdownV2 | Notes |
+|-----------------|------------|-------|
+| `*bold*` | `*bold*` | Same syntax |
+| `_italic_` | `_italic_` | Same syntax |
+| `` `code` `` | `` `code` `` | Same syntax |
+| ` ```pre``` ` | ` ```pre``` ` | Same syntax |
+| `[text](url)` | `[text](url)` | Same syntax |
+| N/A | `__underline__` | New in MarkdownV2 |
+| N/A | `~strikethrough~` | New in MarkdownV2 |
+| N/A | `\|\|spoiler\|\|` | New in MarkdownV2 |
+
+**Key difference:** MarkdownV2 requires escaping more special characters:
+```
+_ * [ ] ( ) ~ ` > # + - = | { } . ! \
+```
+
+---
+
+## Using FormattedString Instead
+
+The best approach is to use `FormattedString` and entity tags from this library. This completely avoids parsing issues because you're working with `MessageEntity` objects directly:
+
+```typescript
+import { fmt, bold, italic, code, link } from "@grammyjs/parse-mode";
+
+// Build formatted text using entity tags
+const message = fmt`
+${bold}Important:${bold} This is ${italic}formatted${italic} text.
+Check out ${link("https://example.com")}this link${link}.
+Use ${code}inline code${code} for commands.
+`;
+
+// Send using entities (no parse_mode needed)
+await ctx.reply(message.text, { entities: message.entities });
+```
+
+This approach:
+- Works consistently regardless of special characters in your text
+- Supports all formatting types (including those not in legacy Markdown)
+- Eliminates escaping headaches
+- Provides type safety

--- a/docs/Markdown.md
+++ b/docs/Markdown.md
@@ -67,13 +67,13 @@ The following formatting options are **NOT available** in legacy Markdown mode:
 import { fmt, bold, FormattedString } from "@grammyjs/parse-mode";
 
 // Using entity tag
-const result = fmt`${bold}bold text${bold}`;
+const fromFmt = fmt`${bold}bold text${bold}`;
 
 // Using static method
-const result = FormattedString.bold("bold text");
+const fromStatic = FormattedString.bold("bold text");
 
-// Using instance method
-const result = FormattedString.b("bold text"); // alias
+// Using static method (alias)
+const fromAlias = FormattedString.b("bold text");
 ```
 
 ---
@@ -91,9 +91,9 @@ const result = FormattedString.b("bold text"); // alias
 ```typescript
 import { fmt, italic, FormattedString } from "@grammyjs/parse-mode";
 
-const result = fmt`${italic}italic text${italic}`;
-const result = FormattedString.italic("italic text");
-const result = FormattedString.i("italic text"); // alias
+const fromFmt = fmt`${italic}italic text${italic}`;
+const fromStatic = FormattedString.italic("italic text");
+const fromAlias = FormattedString.i("italic text"); // alias
 ```
 
 ---
@@ -111,8 +111,8 @@ const result = FormattedString.i("italic text"); // alias
 ```typescript
 import { fmt, code, FormattedString } from "@grammyjs/parse-mode";
 
-const result = fmt`${code}inline code${code}`;
-const result = FormattedString.code("inline code");
+const fromFmt = fmt`${code}inline code${code}`;
+const fromStatic = FormattedString.code("inline code");
 ```
 
 > **Note:** Code entities cannot be combined with other formatting.
@@ -137,7 +137,7 @@ pre-formatted code
 ```typescript
 import { fmt, pre, FormattedString } from "@grammyjs/parse-mode";
 
-const result = fmt`${pre()}pre-formatted code${pre}`;
+const fromFmt = fmt`${pre()}pre-formatted code${pre}`;
 ```
 
 > **Note:** Legacy Markdown does **not** support language specification in code blocks. Use MarkdownV2 or HTML if you need syntax highlighting.
@@ -157,9 +157,9 @@ const result = fmt`${pre()}pre-formatted code${pre}`;
 ```typescript
 import { fmt, link, FormattedString } from "@grammyjs/parse-mode";
 
-const result = fmt`${link("https://example.com")}link text${link}`;
-const result = FormattedString.link("link text", "https://example.com");
-const result = FormattedString.a("link text", "https://example.com"); // alias
+const fromFmt = fmt`${link("https://example.com")}link text${link}`;
+const fromStatic = FormattedString.link("link text", "https://example.com");
+const fromAlias = FormattedString.a("link text", "https://example.com"); // alias
 ```
 
 ---
@@ -177,8 +177,8 @@ const result = FormattedString.a("link text", "https://example.com"); // alias
 ```typescript
 import { FormattedString, mentionUser } from "@grammyjs/parse-mode";
 
-const result = mentionUser("user name", 123456789);
-const result = FormattedString.mentionUser("user name", 123456789);
+const fromFunc = mentionUser("user name", 123456789);
+const fromStatic = FormattedString.mentionUser("user name", 123456789);
 ```
 
 ---

--- a/docs/MarkdownV2.md
+++ b/docs/MarkdownV2.md
@@ -35,7 +35,7 @@ Inside inline link URLs `(...)`, only `)` and `\` need escaping.
 | `[text](tg://user?id=123)` | user mention | `text_link` | `FormattedString.mentionUser(text, userId)` |
 | `![emoji](tg://emoji?id=123)` | custom emoji | `custom_emoji` | `FormattedString.emoji(text, emojiId)` |
 | `>blockquote` | blockquote | `blockquote` | `FormattedString.blockquote()` or `fmt\`${blockquote}...\`` |
-| `**>expandable` | expandable blockquote | `expandable_blockquote` | `FormattedString.expandableBlockquote()` |
+| `**>expandable...||` | expandable blockquote | `expandable_blockquote` | `FormattedString.expandableBlockquote()` |
 
 ---
 
@@ -55,13 +55,13 @@ Inside inline link URLs `(...)`, only `)` and `\` need escaping.
 import { fmt, bold, FormattedString } from "@grammyjs/parse-mode";
 
 // Using entity tag
-const result = fmt`${bold}bold text${bold}`;
+const fromFmt = fmt`${bold}bold text${bold}`;
 
 // Using static method
-const result = FormattedString.bold("bold text");
+const fromStatic = FormattedString.bold("bold text");
 
 // Using instance method
-const result = new FormattedString("").bold("bold text");
+const fromInstance = new FormattedString("").bold("bold text");
 ```
 
 ---
@@ -79,8 +79,8 @@ const result = new FormattedString("").bold("bold text");
 ```typescript
 import { fmt, italic, FormattedString } from "@grammyjs/parse-mode";
 
-const result = fmt`${italic}italic text${italic}`;
-const result = FormattedString.italic("italic text");
+const fromFmt = fmt`${italic}italic text${italic}`;
+const fromStatic = FormattedString.italic("italic text");
 ```
 
 ---
@@ -98,8 +98,8 @@ const result = FormattedString.italic("italic text");
 ```typescript
 import { fmt, underline, FormattedString } from "@grammyjs/parse-mode";
 
-const result = fmt`${underline}underline text${underline}`;
-const result = FormattedString.underline("underline text");
+const fromFmt = fmt`${underline}underline text${underline}`;
+const fromStatic = FormattedString.underline("underline text");
 ```
 
 ---
@@ -117,8 +117,8 @@ const result = FormattedString.underline("underline text");
 ```typescript
 import { fmt, strikethrough, FormattedString } from "@grammyjs/parse-mode";
 
-const result = fmt`${strikethrough}strikethrough text${strikethrough}`;
-const result = FormattedString.strikethrough("strikethrough text");
+const fromFmt = fmt`${strikethrough}strikethrough text${strikethrough}`;
+const fromStatic = FormattedString.strikethrough("strikethrough text");
 ```
 
 ---
@@ -136,8 +136,8 @@ const result = FormattedString.strikethrough("strikethrough text");
 ```typescript
 import { fmt, spoiler, FormattedString } from "@grammyjs/parse-mode";
 
-const result = fmt`${spoiler}spoiler text${spoiler}`;
-const result = FormattedString.spoiler("spoiler text");
+const fromFmt = fmt`${spoiler}spoiler text${spoiler}`;
+const fromStatic = FormattedString.spoiler("spoiler text");
 ```
 
 ---
@@ -155,8 +155,8 @@ const result = FormattedString.spoiler("spoiler text");
 ```typescript
 import { fmt, code, FormattedString } from "@grammyjs/parse-mode";
 
-const result = fmt`${code}inline code${code}`;
-const result = FormattedString.code("inline code");
+const fromFmt = fmt`${code}inline code${code}`;
+const fromStatic = FormattedString.code("inline code");
 ```
 
 > **Note:** Code entities cannot be combined with other formatting (bold, italic, etc.).
@@ -190,11 +190,11 @@ print("Hello")
 import { fmt, pre, FormattedString } from "@grammyjs/parse-mode";
 
 // Without language
-const result = fmt`${pre()}pre-formatted code${pre}`;
+const fromFmt = fmt`${pre()}pre-formatted code${pre}`;
 
 // With language
-const result = fmt`${pre("python")}print("Hello")${pre}`;
-const result = FormattedString.pre('print("Hello")', "python");
+const fromFmtLang = fmt`${pre("python")}print("Hello")${pre}`;
+const fromStatic = FormattedString.pre('print("Hello")', "python");
 ```
 
 > **Note:** Pre entities cannot be combined with other formatting.
@@ -214,8 +214,8 @@ const result = FormattedString.pre('print("Hello")', "python");
 ```typescript
 import { fmt, link, FormattedString } from "@grammyjs/parse-mode";
 
-const result = fmt`${link("https://example.com")}link text${link}`;
-const result = FormattedString.link("link text", "https://example.com");
+const fromFmt = fmt`${link("https://example.com")}link text${link}`;
+const fromStatic = FormattedString.link("link text", "https://example.com");
 ```
 
 ---
@@ -233,8 +233,8 @@ const result = FormattedString.link("link text", "https://example.com");
 ```typescript
 import { FormattedString, mentionUser } from "@grammyjs/parse-mode";
 
-const result = mentionUser("user name", 123456789);
-const result = FormattedString.mentionUser("user name", 123456789);
+const fromFunc = mentionUser("user name", 123456789);
+const fromStatic = FormattedString.mentionUser("user name", 123456789);
 ```
 
 ---
@@ -252,8 +252,8 @@ const result = FormattedString.mentionUser("user name", 123456789);
 ```typescript
 import { fmt, emoji, FormattedString } from "@grammyjs/parse-mode";
 
-const result = fmt`${emoji("5368324170671202286")}👍${emoji}`;
-const result = FormattedString.emoji("👍", "5368324170671202286");
+const fromFmt = fmt`${emoji("5368324170671202286")}👍${emoji}`;
+const fromStatic = FormattedString.emoji("👍", "5368324170671202286");
 ```
 
 ---
@@ -275,8 +275,8 @@ const result = FormattedString.emoji("👍", "5368324170671202286");
 ```typescript
 import { fmt, blockquote, FormattedString } from "@grammyjs/parse-mode";
 
-const result = fmt`${blockquote}Block quotation text${blockquote}`;
-const result = FormattedString.blockquote("Block quotation text");
+const fromFmt = fmt`${blockquote}Block quotation text${blockquote}`;
+const fromStatic = FormattedString.blockquote("Block quotation text");
 ```
 
 ---
@@ -292,15 +292,15 @@ const result = FormattedString.blockquote("Block quotation text");
 
 **MessageEntity:**
 ```json
-{ "type": "expandable_blockquote", "offset": 0, "length": 80 }
+{ "type": "expandable_blockquote", "offset": 0, "length": 108 }
 ```
 
 **FormattedString Usage:**
 ```typescript
 import { fmt, expandableBlockquote, FormattedString } from "@grammyjs/parse-mode";
 
-const result = fmt`${expandableBlockquote}Expandable quotation${expandableBlockquote}`;
-const result = FormattedString.expandableBlockquote("Expandable quotation");
+const fromFmt = fmt`${expandableBlockquote}Expandable quotation${expandableBlockquote}`;
+const fromStatic = FormattedString.expandableBlockquote("Expandable quotation");
 ```
 
 ---
@@ -319,7 +319,7 @@ MarkdownV2 supports limited nesting of entities:
 import { fmt, bold, italic } from "@grammyjs/parse-mode";
 
 // Bold italic text
-const result = fmt`${bold}${italic}bold and italic${italic}${bold}`;
+const boldItalic = fmt`${bold}${italic}bold and italic${italic}${bold}`;
 ```
 
 **MarkdownV2 equivalent:** `*_bold and italic_*`

--- a/docs/MarkdownV2.md
+++ b/docs/MarkdownV2.md
@@ -1,0 +1,325 @@
+# MarkdownV2 Formatting
+
+This document describes the MarkdownV2 formatting style supported by the Telegram Bot API and how each syntax element maps to `MessageEntity` types and `FormattedString` methods in this library.
+
+## Overview
+
+MarkdownV2 is the recommended Markdown-based formatting mode for Telegram bots. It provides a rich set of formatting options with strict escaping rules.
+
+### Special Characters
+
+The following characters must be escaped with a preceding backslash (`\`) when used as literal text:
+
+```
+_ * [ ] ( ) ~ ` > # + - = | { } . ! \
+```
+
+Inside `pre` and `code` entities, only `` ` `` and `\` need escaping.
+Inside inline link URLs `(...)`, only `)` and `\` need escaping.
+
+---
+
+## Entity Reference
+
+| Syntax | Example | MessageEntity Type | FormattedString Method |
+|--------|---------|-------------------|----------------------|
+| `*bold*` | *bold* | `bold` | `FormattedString.bold()` or `fmt\`${bold}...\`` |
+| `_italic_` | _italic_ | `italic` | `FormattedString.italic()` or `fmt\`${italic}...\`` |
+| `__underline__` | underline | `underline` | `FormattedString.underline()` or `fmt\`${underline}...\`` |
+| `~strikethrough~` | ~~strikethrough~~ | `strikethrough` | `FormattedString.strikethrough()` or `fmt\`${strikethrough}...\`` |
+| `\|\|spoiler\|\|` | spoiler | `spoiler` | `FormattedString.spoiler()` or `fmt\`${spoiler}...\`` |
+| `` `code` `` | `code` | `code` | `FormattedString.code()` or `fmt\`${code}...\`` |
+| ` ```pre``` ` | pre block | `pre` | `FormattedString.pre()` or `fmt\`${pre()}...\`` |
+| ` ```language\ncode``` ` | code block | `pre` (with `language`) | `FormattedString.pre(text, "language")` |
+| `[text](url)` | [link](url) | `text_link` | `FormattedString.link(text, url)` or `fmt\`${link(url)}...\`` |
+| `[text](tg://user?id=123)` | user mention | `text_link` | `FormattedString.mentionUser(text, userId)` |
+| `![emoji](tg://emoji?id=123)` | custom emoji | `custom_emoji` | `FormattedString.emoji(text, emojiId)` |
+| `>blockquote` | blockquote | `blockquote` | `FormattedString.blockquote()` or `fmt\`${blockquote}...\`` |
+| `**>expandable` | expandable blockquote | `expandable_blockquote` | `FormattedString.expandableBlockquote()` |
+
+---
+
+## Detailed Entity Descriptions
+
+### Bold
+
+**Syntax:** `*bold text*`
+
+**MessageEntity:**
+```json
+{ "type": "bold", "offset": 0, "length": 9 }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, bold, FormattedString } from "@grammyjs/parse-mode";
+
+// Using entity tag
+const result = fmt`${bold}bold text${bold}`;
+
+// Using static method
+const result = FormattedString.bold("bold text");
+
+// Using instance method
+const result = new FormattedString("").bold("bold text");
+```
+
+---
+
+### Italic
+
+**Syntax:** `_italic text_`
+
+**MessageEntity:**
+```json
+{ "type": "italic", "offset": 0, "length": 11 }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, italic, FormattedString } from "@grammyjs/parse-mode";
+
+const result = fmt`${italic}italic text${italic}`;
+const result = FormattedString.italic("italic text");
+```
+
+---
+
+### Underline
+
+**Syntax:** `__underline text__`
+
+**MessageEntity:**
+```json
+{ "type": "underline", "offset": 0, "length": 14 }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, underline, FormattedString } from "@grammyjs/parse-mode";
+
+const result = fmt`${underline}underline text${underline}`;
+const result = FormattedString.underline("underline text");
+```
+
+---
+
+### Strikethrough
+
+**Syntax:** `~strikethrough text~`
+
+**MessageEntity:**
+```json
+{ "type": "strikethrough", "offset": 0, "length": 18 }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, strikethrough, FormattedString } from "@grammyjs/parse-mode";
+
+const result = fmt`${strikethrough}strikethrough text${strikethrough}`;
+const result = FormattedString.strikethrough("strikethrough text");
+```
+
+---
+
+### Spoiler
+
+**Syntax:** `||spoiler text||`
+
+**MessageEntity:**
+```json
+{ "type": "spoiler", "offset": 0, "length": 12 }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, spoiler, FormattedString } from "@grammyjs/parse-mode";
+
+const result = fmt`${spoiler}spoiler text${spoiler}`;
+const result = FormattedString.spoiler("spoiler text");
+```
+
+---
+
+### Inline Code
+
+**Syntax:** `` `inline code` ``
+
+**MessageEntity:**
+```json
+{ "type": "code", "offset": 0, "length": 11 }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, code, FormattedString } from "@grammyjs/parse-mode";
+
+const result = fmt`${code}inline code${code}`;
+const result = FormattedString.code("inline code");
+```
+
+> **Note:** Code entities cannot be combined with other formatting (bold, italic, etc.).
+
+---
+
+### Pre-formatted Code Block
+
+**Syntax:**
+````
+```
+pre-formatted code
+```
+````
+
+**With language:**
+````
+```python
+print("Hello")
+```
+````
+
+**MessageEntity:**
+```json
+{ "type": "pre", "offset": 0, "length": 18 }
+{ "type": "pre", "offset": 0, "length": 14, "language": "python" }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, pre, FormattedString } from "@grammyjs/parse-mode";
+
+// Without language
+const result = fmt`${pre()}pre-formatted code${pre}`;
+
+// With language
+const result = fmt`${pre("python")}print("Hello")${pre}`;
+const result = FormattedString.pre('print("Hello")', "python");
+```
+
+> **Note:** Pre entities cannot be combined with other formatting.
+
+---
+
+### Text Link
+
+**Syntax:** `[link text](https://example.com)`
+
+**MessageEntity:**
+```json
+{ "type": "text_link", "offset": 0, "length": 9, "url": "https://example.com" }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, link, FormattedString } from "@grammyjs/parse-mode";
+
+const result = fmt`${link("https://example.com")}link text${link}`;
+const result = FormattedString.link("link text", "https://example.com");
+```
+
+---
+
+### User Mention (Text Mention)
+
+**Syntax:** `[user name](tg://user?id=123456789)`
+
+**MessageEntity:**
+```json
+{ "type": "text_link", "offset": 0, "length": 9, "url": "tg://user?id=123456789" }
+```
+
+**FormattedString Usage:**
+```typescript
+import { FormattedString, mentionUser } from "@grammyjs/parse-mode";
+
+const result = mentionUser("user name", 123456789);
+const result = FormattedString.mentionUser("user name", 123456789);
+```
+
+---
+
+### Custom Emoji
+
+**Syntax:** `![👍](tg://emoji?id=5368324170671202286)`
+
+**MessageEntity:**
+```json
+{ "type": "custom_emoji", "offset": 0, "length": 2, "custom_emoji_id": "5368324170671202286" }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, emoji, FormattedString } from "@grammyjs/parse-mode";
+
+const result = fmt`${emoji("5368324170671202286")}👍${emoji}`;
+const result = FormattedString.emoji("👍", "5368324170671202286");
+```
+
+---
+
+### Blockquote
+
+**Syntax:**
+```
+>Block quotation started
+>Block quotation continued
+```
+
+**MessageEntity:**
+```json
+{ "type": "blockquote", "offset": 0, "length": 52 }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, blockquote, FormattedString } from "@grammyjs/parse-mode";
+
+const result = fmt`${blockquote}Block quotation text${blockquote}`;
+const result = FormattedString.blockquote("Block quotation text");
+```
+
+---
+
+### Expandable Blockquote
+
+**Syntax:**
+```
+**>Expandable block quotation started
+>Expandable block quotation continued
+>The last line of the block quotation||
+```
+
+**MessageEntity:**
+```json
+{ "type": "expandable_blockquote", "offset": 0, "length": 80 }
+```
+
+**FormattedString Usage:**
+```typescript
+import { fmt, expandableBlockquote, FormattedString } from "@grammyjs/parse-mode";
+
+const result = fmt`${expandableBlockquote}Expandable quotation${expandableBlockquote}`;
+const result = FormattedString.expandableBlockquote("Expandable quotation");
+```
+
+---
+
+## Nesting Rules
+
+MarkdownV2 supports limited nesting of entities:
+
+- **Allowed nesting:** Bold, italic, underline, strikethrough, and spoiler can be nested within each other
+- **Cannot nest:** `code` and `pre` entities cannot contain or be contained by other formatting
+- **Blockquotes:** Cannot be nested within other blockquotes
+
+### Example: Nested Formatting
+
+```typescript
+import { fmt, bold, italic } from "@grammyjs/parse-mode";
+
+// Bold italic text
+const result = fmt`${bold}${italic}bold and italic${italic}${bold}`;
+```
+
+**MarkdownV2 equivalent:** `*_bold and italic_*`


### PR DESCRIPTION
Add comprehensive documentation for all three Telegram formatting styles:
- MarkdownV2.md: Full entity reference with syntax, MessageEntity types, and FormattedString mappings
- HTML.md: HTML tag reference with all supported elements and nesting rules
- Markdown.md: Legacy format documentation with deprecation notice and migration guide

Each document includes:
- Entity reference tables
- Detailed syntax examples
- MessageEntity JSON structures
- FormattedString usage examples
- Nesting rules and limitations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive HTML text formatting guide including supported elements, special character escaping, detailed usage examples, and nesting rules.
  * Added documentation for legacy Markdown formatting with deprecation notice and clear migration guidance to MarkdownV2.
  * Added detailed MarkdownV2 formatting guide covering syntax patterns, supported formatting types, nesting capabilities, language-specific code blocks, and comprehensive usage examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->