### PR TITLE
docs: remove examples column from entity reference tables

### DIFF
--- a/docs/Markdown.md
+++ b/docs/Markdown.md
@@ -28,10 +28,10 @@ Use `\` to escape these characters when you want them as literal text.
 
 | Syntax | MessageEntity Type | FormattedString Method |
 |--------|-------------------|----------------------|
-| `*bold*` | `bold` | `FormattedString.bold()` or `fmt\`${bold}...\`` |
-| `_italic_` | `italic` | `FormattedString.italic()` or `fmt\`${italic}...\`` |
-| `` `code` `` | `code` | `FormattedString.code()` or `fmt\`${code}...\`` |
-| ` ```pre``` ` | `pre` | `FormattedString.pre()` or `fmt\`${pre()}...\`` |
+| `*bold*` | `bold` | `FormattedString.bold()` |
+| `_italic_` | `italic` | `FormattedString.italic()` |
+| `` `code` `` | `code` | `FormattedString.code()` |
+| ` ```pre``` ` | `pre` | `FormattedString.pre()` |
 | `[text](url)` | `text_link` | `FormattedString.link(text, url)` |
 | `[text](tg://user?id=123)` | `text_link` | `FormattedString.mentionUser(text, userId)` |
 

--- a/docs/Markdown.md
+++ b/docs/Markdown.md
@@ -26,14 +26,14 @@ Use `\` to escape these characters when you want them as literal text.
 
 ## Entity Reference
 
-| Syntax | Example | MessageEntity Type | FormattedString Method |
-|--------|---------|-------------------|----------------------|
-| `*bold*` | *bold* | `bold` | `FormattedString.bold()` or `fmt\`${bold}...\`` |
-| `_italic_` | _italic_ | `italic` | `FormattedString.italic()` or `fmt\`${italic}...\`` |
-| `` `code` `` | `code` | `code` | `FormattedString.code()` or `fmt\`${code}...\`` |
-| ` ```pre``` ` | pre block | `pre` | `FormattedString.pre()` or `fmt\`${pre()}...\`` |
-| `[text](url)` | [link](url) | `text_link` | `FormattedString.link(text, url)` |
-| `[text](tg://user?id=123)` | user mention | `text_link` | `FormattedString.mentionUser(text, userId)` |
+| Syntax | MessageEntity Type | FormattedString Method |
+|--------|-------------------|----------------------|
+| `*bold*` | `bold` | `FormattedString.bold()` or `fmt\`${bold}...\`` |
+| `_italic_` | `italic` | `FormattedString.italic()` or `fmt\`${italic}...\`` |
+| `` `code` `` | `code` | `FormattedString.code()` or `fmt\`${code}...\`` |
+| ` ```pre``` ` | `pre` | `FormattedString.pre()` or `fmt\`${pre()}...\`` |
+| `[text](url)` | `text_link` | `FormattedString.link(text, url)` |
+| `[text](tg://user?id=123)` | `text_link` | `FormattedString.mentionUser(text, userId)` |
 
 ### Not Supported in Legacy Markdown
 

--- a/docs/MarkdownV2.md
+++ b/docs/MarkdownV2.md
@@ -23,18 +23,18 @@ Inside inline link URLs `(...)`, only `)` and `\` need escaping.
 
 | Syntax | MessageEntity Type | FormattedString Method |
 |--------|-------------------|----------------------|
-| `*bold*` | `bold` | `FormattedString.bold()` or `fmt\`${bold}...\`` |
-| `_italic_` | `italic` | `FormattedString.italic()` or `fmt\`${italic}...\`` |
-| `__underline__` | `underline` | `FormattedString.underline()` or `fmt\`${underline}...\`` |
-| `~strikethrough~` | `strikethrough` | `FormattedString.strikethrough()` or `fmt\`${strikethrough}...\`` |
-| `\|\|spoiler\|\|` | `spoiler` | `FormattedString.spoiler()` or `fmt\`${spoiler}...\`` |
-| `` `code` `` | `code` | `FormattedString.code()` or `fmt\`${code}...\`` |
-| ` ```pre``` ` | `pre` | `FormattedString.pre()` or `fmt\`${pre()}...\`` |
+| `*bold*` | `bold` | `FormattedString.bold()` |
+| `_italic_` | `italic` | `FormattedString.italic()` |
+| `__underline__` | `underline` | `FormattedString.underline()` |
+| `~strikethrough~` | `strikethrough` | `FormattedString.strikethrough()` |
+| `\|\|spoiler\|\|` | `spoiler` | `FormattedString.spoiler()` |
+| `` `code` `` | `code` | `FormattedString.code()` |
+| ` ```pre``` ` | `pre` | `FormattedString.pre()` |
 | ` ```language\ncode``` ` | `pre` (with `language`) | `FormattedString.pre(text, "language")` |
-| `[text](url)` | `text_link` | `FormattedString.link(text, url)` or `fmt\`${link(url)}...\`` |
+| `[text](url)` | `text_link` | `FormattedString.link(text, url)` |
 | `[text](tg://user?id=123)` | `text_link` | `FormattedString.mentionUser(text, userId)` |
 | `![emoji](tg://emoji?id=123)` | `custom_emoji` | `FormattedString.emoji(text, emojiId)` |
-| `>blockquote` | `blockquote` | `FormattedString.blockquote()` or `fmt\`${blockquote}...\`` |
+| `>blockquote` | `blockquote` | `FormattedString.blockquote()` |
 | `**>expandable...\|\|` | `expandable_blockquote` | `FormattedString.expandableBlockquote()` |
 
 ---

--- a/docs/MarkdownV2.md
+++ b/docs/MarkdownV2.md
@@ -21,21 +21,21 @@ Inside inline link URLs `(...)`, only `)` and `\` need escaping.
 
 ## Entity Reference
 
-| Syntax | Example | MessageEntity Type | FormattedString Method |
-|--------|---------|-------------------|----------------------|
-| `*bold*` | *bold* | `bold` | `FormattedString.bold()` or `fmt\`${bold}...\`` |
-| `_italic_` | _italic_ | `italic` | `FormattedString.italic()` or `fmt\`${italic}...\`` |
-| `__underline__` | underline | `underline` | `FormattedString.underline()` or `fmt\`${underline}...\`` |
-| `~strikethrough~` | ~~strikethrough~~ | `strikethrough` | `FormattedString.strikethrough()` or `fmt\`${strikethrough}...\`` |
-| `\|\|spoiler\|\|` | spoiler | `spoiler` | `FormattedString.spoiler()` or `fmt\`${spoiler}...\`` |
-| `` `code` `` | `code` | `code` | `FormattedString.code()` or `fmt\`${code}...\`` |
-| ` ```pre``` ` | pre block | `pre` | `FormattedString.pre()` or `fmt\`${pre()}...\`` |
-| ` ```language\ncode``` ` | code block | `pre` (with `language`) | `FormattedString.pre(text, "language")` |
-| `[text](url)` | [link](url) | `text_link` | `FormattedString.link(text, url)` or `fmt\`${link(url)}...\`` |
-| `[text](tg://user?id=123)` | user mention | `text_link` | `FormattedString.mentionUser(text, userId)` |
-| `![emoji](tg://emoji?id=123)` | custom emoji | `custom_emoji` | `FormattedString.emoji(text, emojiId)` |
-| `>blockquote` | blockquote | `blockquote` | `FormattedString.blockquote()` or `fmt\`${blockquote}...\`` |
-| `**>expandable...||` | expandable blockquote | `expandable_blockquote` | `FormattedString.expandableBlockquote()` |
+| Syntax | MessageEntity Type | FormattedString Method |
+|--------|-------------------|----------------------|
+| `*bold*` | `bold` | `FormattedString.bold()` or `fmt\`${bold}...\`` |
+| `_italic_` | `italic` | `FormattedString.italic()` or `fmt\`${italic}...\`` |
+| `__underline__` | `underline` | `FormattedString.underline()` or `fmt\`${underline}...\`` |
+| `~strikethrough~` | `strikethrough` | `FormattedString.strikethrough()` or `fmt\`${strikethrough}...\`` |
+| `\|\|spoiler\|\|` | `spoiler` | `FormattedString.spoiler()` or `fmt\`${spoiler}...\`` |
+| `` `code` `` | `code` | `FormattedString.code()` or `fmt\`${code}...\`` |
+| ` ```pre``` ` | `pre` | `FormattedString.pre()` or `fmt\`${pre()}...\`` |
+| ` ```language\ncode``` ` | `pre` (with `language`) | `FormattedString.pre(text, "language")` |
+| `[text](url)` | `text_link` | `FormattedString.link(text, url)` or `fmt\`${link(url)}...\`` |
+| `[text](tg://user?id=123)` | `text_link` | `FormattedString.mentionUser(text, userId)` |
+| `![emoji](tg://emoji?id=123)` | `custom_emoji` | `FormattedString.emoji(text, emojiId)` |
+| `>blockquote` | `blockquote` | `FormattedString.blockquote()` or `fmt\`${blockquote}...\`` |
+| `**>expandable...\|\|` | `expandable_blockquote` | `FormattedString.expandableBlockquote()` |
 
 ---
 


### PR DESCRIPTION
Remove the 'Example' column from entity reference tables in Markdown.md and MarkdownV2.md to match the format used in HTML.md.

Also fix the broken table in MarkdownV2.md caused by incorrectly escaped markdown (|| in expandable blockquote row).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Streamlined Entity Reference tables in Markdown documentation by removing examples and consolidating columns to focus on Syntax, MessageEntity Type, and FormattedString Method mappings for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->