### PR TITLE
feat: add HTML parser with FormattedString.fromHtml()

### DIFF
--- a/src/html-parser.ts
+++ b/src/html-parser.ts
@@ -1,0 +1,374 @@
+import {
+  a,
+  b,
+  blockquote,
+  code,
+  emoji,
+  EntityTag,
+  expandableBlockquote,
+  i,
+  pre,
+  s,
+  spoiler,
+  u,
+} from "./entity-tag.ts";
+
+/**
+ * Parser states for the finite state machine
+ */
+const enum State {
+  /** Normal text parsing */
+  TEXT,
+  /** After seeing '&', parsing entity name */
+  ENTITY,
+  /** After seeing '<', waiting to determine tag type */
+  TAG_OPEN,
+  /** Parsing tag name and attributes */
+  TAG_CONTENT,
+}
+
+/** Supported HTML entity mappings */
+const HTML_ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  nbsp: "\u00A0",
+};
+
+/**
+ * Parses tag attributes from a space-separated string.
+ * Handles: name="value", name='value', name=value, and boolean attributes.
+ * @param attrString The attribute string after the tag name
+ * @returns Record of attribute name to value
+ */
+function parseAttributes(attrString: string): Record<string, string> {
+  const attributes: Record<string, string> = {};
+  let remaining = attrString.trim();
+
+  while (remaining.length > 0) {
+    // Find attribute name (ends at '=' or whitespace)
+    const nameEnd = remaining.search(/[=\s]/);
+    if (nameEnd === -1) {
+      // Boolean attribute at end
+      attributes[remaining] = "";
+      break;
+    }
+
+    const attrName = remaining.slice(0, nameEnd);
+    remaining = remaining.slice(nameEnd).trimStart();
+
+    if (!remaining.startsWith("=")) {
+      // Boolean attribute
+      attributes[attrName] = "";
+      continue;
+    }
+
+    // Skip '='
+    remaining = remaining.slice(1).trimStart();
+
+    let value: string;
+    if (remaining.startsWith('"')) {
+      // Double-quoted value
+      const endQuote = remaining.indexOf('"', 1);
+      if (endQuote === -1) {
+        value = remaining.slice(1);
+        remaining = "";
+      } else {
+        value = remaining.slice(1, endQuote);
+        remaining = remaining.slice(endQuote + 1).trimStart();
+      }
+    } else if (remaining.startsWith("'")) {
+      // Single-quoted value
+      const endQuote = remaining.indexOf("'", 1);
+      if (endQuote === -1) {
+        value = remaining.slice(1);
+        remaining = "";
+      } else {
+        value = remaining.slice(1, endQuote);
+        remaining = remaining.slice(endQuote + 1).trimStart();
+      }
+    } else {
+      // Unquoted value (ends at whitespace)
+      const valueEnd = remaining.search(/\s/);
+      if (valueEnd === -1) {
+        value = remaining;
+        remaining = "";
+      } else {
+        value = remaining.slice(0, valueEnd);
+        remaining = remaining.slice(valueEnd).trimStart();
+      }
+    }
+
+    attributes[attrName] = value;
+  }
+
+  return attributes;
+}
+
+/**
+ * Converts a tag name and attributes to EntityTag(s).
+ * @param tagName The HTML tag name (may include leading '/')
+ * @param attributes The tag attributes
+ * @returns Array of EntityTags, or undefined if the tag is not supported
+ */
+function tagToEntityTags(
+  tagName: string,
+  attributes: Record<string, string>,
+): EntityTag[] | undefined {
+  const lowerTagName = tagName.toLowerCase();
+
+  switch (lowerTagName) {
+    // Bold
+    case "b":
+    case "/b":
+    case "strong":
+    case "/strong":
+      return [b()];
+
+    // Italic
+    case "i":
+    case "/i":
+    case "em":
+    case "/em":
+      return [i()];
+
+    // Underline
+    case "u":
+    case "/u":
+    case "ins":
+    case "/ins":
+      return [u()];
+
+    // Strikethrough
+    case "s":
+    case "/s":
+    case "strike":
+    case "/strike":
+    case "del":
+    case "/del":
+      return [s()];
+
+    // Spoiler
+    case "tg-spoiler":
+    case "/tg-spoiler":
+      return [spoiler()];
+    case "span":
+      // Only span with class="tg-spoiler" is valid
+      if (attributes["class"] === "tg-spoiler") {
+        return [spoiler()];
+      }
+      return undefined;
+    case "/span":
+      // Closing span always matches spoiler (if there was an opening tg-spoiler span)
+      return [spoiler()];
+
+    // Links
+    case "a":
+      if (attributes["href"]) {
+        return [a(attributes["href"])];
+      }
+      return undefined;
+    case "/a":
+      return [a("")];
+
+    // Custom emoji
+    case "tg-emoji":
+      if (attributes["emoji-id"]) {
+        return [emoji(attributes["emoji-id"])];
+      }
+      return undefined;
+    case "/tg-emoji":
+      return [emoji("")];
+
+    // Code
+    case "code":
+    case "/code":
+      return [code()];
+
+    // Pre (code block)
+    case "pre":
+      return [pre(attributes["language"])];
+    case "/pre":
+      return [pre()];
+
+    // Blockquote
+    case "blockquote":
+      // Check for expandable attribute
+      if ("expandable" in attributes) {
+        return [expandableBlockquote()];
+      }
+      return [blockquote()];
+    case "/blockquote":
+      // Closing tag could match either blockquote type - emit both
+      return [expandableBlockquote(), blockquote()];
+
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Parses HTML string into text parts and entity tags suitable for fmt.
+ * Uses a character-by-character finite state machine parser.
+ *
+ * @param html The HTML string to parse
+ * @returns Object containing interleaved text parts and entity tags
+ */
+export function parseHtml(html: string): {
+  textParts: string[];
+  entityTagParts: EntityTag[];
+} {
+  let state = State.TEXT;
+  let textBuffer = "";
+  let entityBuffer = "";
+  let tagBuffer = "";
+
+  const textParts: string[] = [];
+  const entityTagParts: EntityTag[] = [];
+
+  for (const char of html) {
+    switch (state) {
+      case State.TEXT:
+        if (char === "<") {
+          state = State.TAG_OPEN;
+        } else if (char === "&") {
+          state = State.ENTITY;
+        } else {
+          textBuffer += char;
+        }
+        break;
+
+      case State.ENTITY:
+        if (char === ";") {
+          // End of entity reference
+          const decoded = HTML_ENTITIES[entityBuffer];
+          if (decoded !== undefined) {
+            textBuffer += decoded;
+          } else if (entityBuffer.startsWith("#x")) {
+            // Hex numeric entity: &#xHHHH;
+            const codePoint = parseInt(entityBuffer.slice(2), 16);
+            if (!isNaN(codePoint)) {
+              textBuffer += String.fromCodePoint(codePoint);
+            } else {
+              textBuffer += `&${entityBuffer};`;
+            }
+          } else if (entityBuffer.startsWith("#")) {
+            // Decimal numeric entity: &#NNNN;
+            const codePoint = parseInt(entityBuffer.slice(1), 10);
+            if (!isNaN(codePoint)) {
+              textBuffer += String.fromCodePoint(codePoint);
+            } else {
+              textBuffer += `&${entityBuffer};`;
+            }
+          } else {
+            // Unknown entity, keep as-is
+            textBuffer += `&${entityBuffer};`;
+          }
+          entityBuffer = "";
+          state = State.TEXT;
+        } else if (char === "&") {
+          // New entity starts, flush previous incomplete entity
+          textBuffer += `&${entityBuffer}`;
+          entityBuffer = "";
+        } else if (char === "<") {
+          // Tag starts, flush incomplete entity
+          textBuffer += `&${entityBuffer}`;
+          entityBuffer = "";
+          state = State.TAG_OPEN;
+        } else {
+          entityBuffer += char;
+        }
+        break;
+
+      case State.TAG_OPEN:
+        if (char === "<") {
+          // Another '<', first one was literal
+          textBuffer += "<";
+        } else if (char === ">") {
+          // Empty tag "<>", treat as literal
+          textBuffer += "<>";
+          state = State.TEXT;
+        } else {
+          // Start building tag content
+          tagBuffer = char;
+          state = State.TAG_CONTENT;
+        }
+        break;
+
+      case State.TAG_CONTENT:
+        if (char === ">") {
+          // End of tag, process it
+          const spaceIndex = tagBuffer.search(/\s/);
+          let tagName: string;
+          let attrString: string;
+
+          if (spaceIndex === -1) {
+            tagName = tagBuffer;
+            attrString = "";
+          } else {
+            tagName = tagBuffer.slice(0, spaceIndex);
+            attrString = tagBuffer.slice(spaceIndex + 1);
+          }
+
+          const attributes = parseAttributes(attrString);
+          const entityTags = tagToEntityTags(tagName, attributes);
+
+          if (entityTags !== undefined && entityTags.length > 0) {
+            // Valid tag, flush text buffer and add entities
+            textParts.push(textBuffer);
+            textBuffer = "";
+            // Add all entity tags, with empty strings between them
+            for (let i = 0; i < entityTags.length; i++) {
+              entityTagParts.push(entityTags[i]);
+              if (i < entityTags.length - 1) {
+                textParts.push("");
+              }
+            }
+          } else {
+            // Unknown tag, treat as literal text
+            textBuffer += `<${tagBuffer}>`;
+          }
+
+          tagBuffer = "";
+          state = State.TEXT;
+        } else if (char === "<") {
+          // Malformed: new tag starts before current one closed
+          // Treat previous '<' + buffer as literal
+          textBuffer += `<${tagBuffer}`;
+          tagBuffer = "";
+          state = State.TAG_OPEN;
+        } else {
+          tagBuffer += char;
+        }
+        break;
+    }
+  }
+
+  // Handle remaining buffers based on final state
+  switch (state) {
+    case State.ENTITY:
+      textBuffer += `&${entityBuffer}`;
+      break;
+    case State.TAG_OPEN:
+      textBuffer += "<";
+      break;
+    case State.TAG_CONTENT:
+      textBuffer += `<${tagBuffer}`;
+      break;
+  }
+
+  // Push final text buffer if non-empty
+  if (textBuffer.length > 0) {
+    textParts.push(textBuffer);
+  }
+
+  // Ensure textParts has one more element than entityTagParts for fmt compatibility
+  // fmt expects: textParts[0] + entityTag[0] + textParts[1] + entityTag[1] + ... + textParts[n]
+  if (textParts.length === entityTagParts.length && entityTagParts.length > 0) {
+    textParts.push("");
+  }
+
+  return { textParts, entityTagParts };
+}

--- a/test/format.html.test.ts
+++ b/test/format.html.test.ts
@@ -1,0 +1,597 @@
+import { assertEquals, describe, it } from "./deps.test.ts";
+import { FormattedString } from "../src/format.ts";
+
+describe("FormattedString.fromHtml - Basic HTML tags", () => {
+  it("should parse bold text with <b>", () => {
+    const formatted = FormattedString.fromHtml("<b>Hello</b>");
+    assertEquals(formatted.text, "Hello");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "bold");
+    assertEquals(formatted.entities[0].offset, 0);
+    assertEquals(formatted.entities[0].length, 5);
+  });
+
+  it("should parse bold text with <strong>", () => {
+    const formatted = FormattedString.fromHtml("<strong>Hello</strong>");
+    assertEquals(formatted.text, "Hello");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "bold");
+    assertEquals(formatted.entities[0].offset, 0);
+    assertEquals(formatted.entities[0].length, 5);
+  });
+
+  it("should parse italic text with <i>", () => {
+    const formatted = FormattedString.fromHtml("<i>World</i>");
+    assertEquals(formatted.text, "World");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "italic");
+    assertEquals(formatted.entities[0].offset, 0);
+    assertEquals(formatted.entities[0].length, 5);
+  });
+
+  it("should parse italic text with <em>", () => {
+    const formatted = FormattedString.fromHtml("<em>World</em>");
+    assertEquals(formatted.text, "World");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "italic");
+    assertEquals(formatted.entities[0].offset, 0);
+    assertEquals(formatted.entities[0].length, 5);
+  });
+
+  it("should parse underline text with <u>", () => {
+    const formatted = FormattedString.fromHtml("<u>Underlined</u>");
+    assertEquals(formatted.text, "Underlined");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "underline");
+    assertEquals(formatted.entities[0].offset, 0);
+    assertEquals(formatted.entities[0].length, 10);
+  });
+
+  it("should parse underline text with <ins>", () => {
+    const formatted = FormattedString.fromHtml("<ins>Underlined</ins>");
+    assertEquals(formatted.text, "Underlined");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "underline");
+    assertEquals(formatted.entities[0].offset, 0);
+    assertEquals(formatted.entities[0].length, 10);
+  });
+
+  it("should parse strikethrough text with <s>", () => {
+    const formatted = FormattedString.fromHtml("<s>Strike</s>");
+    assertEquals(formatted.text, "Strike");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "strikethrough");
+    assertEquals(formatted.entities[0].offset, 0);
+    assertEquals(formatted.entities[0].length, 6);
+  });
+
+  it("should parse strikethrough text with <strike>", () => {
+    const formatted = FormattedString.fromHtml("<strike>Strike</strike>");
+    assertEquals(formatted.text, "Strike");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "strikethrough");
+    assertEquals(formatted.entities[0].offset, 0);
+    assertEquals(formatted.entities[0].length, 6);
+  });
+
+  it("should parse strikethrough text with <del>", () => {
+    const formatted = FormattedString.fromHtml("<del>Strike</del>");
+    assertEquals(formatted.text, "Strike");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "strikethrough");
+    assertEquals(formatted.entities[0].offset, 0);
+    assertEquals(formatted.entities[0].length, 6);
+  });
+
+  it("should parse code text with <code>", () => {
+    const formatted = FormattedString.fromHtml("<code>code</code>");
+    assertEquals(formatted.text, "code");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "code");
+    assertEquals(formatted.entities[0].offset, 0);
+    assertEquals(formatted.entities[0].length, 4);
+  });
+
+  it("should parse pre text with <pre>", () => {
+    const formatted = FormattedString.fromHtml("<pre>code block</pre>");
+    assertEquals(formatted.text, "code block");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "pre");
+    assertEquals(formatted.entities[0].offset, 0);
+    assertEquals(formatted.entities[0].length, 10);
+  });
+
+  it("should parse pre text with language attribute", () => {
+    const formatted = FormattedString.fromHtml(
+      '<pre language="python">code block</pre>',
+    );
+    assertEquals(formatted.text, "code block");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "pre");
+    assertEquals(formatted.entities[0].offset, 0);
+    assertEquals(formatted.entities[0].length, 10);
+    // @ts-expect-error accessing language property
+    assertEquals(formatted.entities[0].language, "python");
+  });
+
+  it("should parse link with <a href>", () => {
+    const formatted = FormattedString.fromHtml(
+      '<a href="https://example.com">link</a>',
+    );
+    assertEquals(formatted.text, "link");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "text_link");
+    assertEquals(formatted.entities[0].offset, 0);
+    assertEquals(formatted.entities[0].length, 4);
+    // @ts-expect-error accessing url property
+    assertEquals(formatted.entities[0].url, "https://example.com");
+  });
+
+  it("should parse spoiler with <tg-spoiler>", () => {
+    const formatted = FormattedString.fromHtml(
+      "<tg-spoiler>secret</tg-spoiler>",
+    );
+    assertEquals(formatted.text, "secret");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "spoiler");
+    assertEquals(formatted.entities[0].offset, 0);
+    assertEquals(formatted.entities[0].length, 6);
+  });
+
+  it('should parse spoiler with <span class="tg-spoiler">', () => {
+    const formatted = FormattedString.fromHtml(
+      '<span class="tg-spoiler">secret</span>',
+    );
+    assertEquals(formatted.text, "secret");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "spoiler");
+    assertEquals(formatted.entities[0].offset, 0);
+    assertEquals(formatted.entities[0].length, 6);
+  });
+
+  it("should parse blockquote with <blockquote>", () => {
+    const formatted = FormattedString.fromHtml(
+      "<blockquote>quote</blockquote>",
+    );
+    assertEquals(formatted.text, "quote");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "blockquote");
+    assertEquals(formatted.entities[0].offset, 0);
+    assertEquals(formatted.entities[0].length, 5);
+  });
+
+  it("should parse expandable blockquote with <blockquote expandable>", () => {
+    const formatted = FormattedString.fromHtml(
+      "<blockquote expandable>expandable quote</blockquote>",
+    );
+    assertEquals(formatted.text, "expandable quote");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "expandable_blockquote");
+    assertEquals(formatted.entities[0].offset, 0);
+    assertEquals(formatted.entities[0].length, 16);
+  });
+
+  it("should parse custom emoji with <tg-emoji>", () => {
+    const formatted = FormattedString.fromHtml(
+      '<tg-emoji emoji-id="12345">👍</tg-emoji>',
+    );
+    assertEquals(formatted.text, "👍");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "custom_emoji");
+    assertEquals(formatted.entities[0].offset, 0);
+    assertEquals(formatted.entities[0].length, 2);
+    // @ts-expect-error accessing custom_emoji_id property
+    assertEquals(formatted.entities[0].custom_emoji_id, "12345");
+  });
+});
+
+describe("FormattedString.fromHtml - Combined formatting", () => {
+  it("should parse multiple adjacent tags", () => {
+    const formatted = FormattedString.fromHtml("<b>Hello</b> <i>World</i>");
+    assertEquals(formatted.text, "Hello World");
+    assertEquals(formatted.entities.length, 2);
+    assertEquals(formatted.entities[0].type, "bold");
+    assertEquals(formatted.entities[0].offset, 0);
+    assertEquals(formatted.entities[0].length, 5);
+    assertEquals(formatted.entities[1].type, "italic");
+    assertEquals(formatted.entities[1].offset, 6);
+    assertEquals(formatted.entities[1].length, 5);
+  });
+
+  it("should parse nested tags", () => {
+    const formatted = FormattedString.fromHtml("<b>Bold <i>and italic</i></b>");
+    assertEquals(formatted.text, "Bold and italic");
+    assertEquals(formatted.entities.length, 2);
+    assertEquals(formatted.entities[0].type, "bold");
+    assertEquals(formatted.entities[0].offset, 0);
+    assertEquals(formatted.entities[0].length, 15);
+    assertEquals(formatted.entities[1].type, "italic");
+    assertEquals(formatted.entities[1].offset, 5);
+    assertEquals(formatted.entities[1].length, 10);
+  });
+
+  it("should parse text with multiple formatting", () => {
+    const formatted = FormattedString.fromHtml(
+      "<b>Bold</b>, <i>italic</i>, and <u>underline</u>",
+    );
+    assertEquals(formatted.text, "Bold, italic, and underline");
+    assertEquals(formatted.entities.length, 3);
+    assertEquals(formatted.entities[0].type, "bold");
+    assertEquals(formatted.entities[0].offset, 0);
+    assertEquals(formatted.entities[0].length, 4);
+    assertEquals(formatted.entities[1].type, "italic");
+    assertEquals(formatted.entities[1].offset, 6);
+    assertEquals(formatted.entities[1].length, 6);
+    assertEquals(formatted.entities[2].type, "underline");
+    assertEquals(formatted.entities[2].offset, 18);
+    assertEquals(formatted.entities[2].length, 9);
+  });
+
+  it("should parse complex nested formatting", () => {
+    const formatted = FormattedString.fromHtml(
+      "<b>Bold <i>bold-italic <u>bold-italic-underline</u></i></b>",
+    );
+    assertEquals(formatted.text, "Bold bold-italic bold-italic-underline");
+    assertEquals(formatted.entities.length, 3);
+    assertEquals(formatted.entities[0].type, "bold");
+    assertEquals(formatted.entities[0].offset, 0);
+    assertEquals(formatted.entities[0].length, 38);
+    assertEquals(formatted.entities[1].type, "italic");
+    assertEquals(formatted.entities[1].offset, 5);
+    assertEquals(formatted.entities[1].length, 33);
+    assertEquals(formatted.entities[2].type, "underline");
+    assertEquals(formatted.entities[2].offset, 17);
+    assertEquals(formatted.entities[2].length, 21);
+  });
+});
+
+describe("FormattedString.fromHtml - HTML entities", () => {
+  it("should decode &lt; entity", () => {
+    const formatted = FormattedString.fromHtml("&lt;tag&gt;");
+    assertEquals(formatted.text, "<tag>");
+    assertEquals(formatted.entities.length, 0);
+  });
+
+  it("should decode &amp; entity", () => {
+    const formatted = FormattedString.fromHtml("A &amp; B");
+    assertEquals(formatted.text, "A & B");
+    assertEquals(formatted.entities.length, 0);
+  });
+
+  it("should decode &quot; entity", () => {
+    const formatted = FormattedString.fromHtml("Say &quot;hello&quot;");
+    assertEquals(formatted.text, 'Say "hello"');
+    assertEquals(formatted.entities.length, 0);
+  });
+
+  it("should decode &apos; entity", () => {
+    const formatted = FormattedString.fromHtml("It&apos;s working");
+    assertEquals(formatted.text, "It's working");
+    assertEquals(formatted.entities.length, 0);
+  });
+
+  it("should decode &nbsp; entity", () => {
+    const formatted = FormattedString.fromHtml("Hello&nbsp;World");
+    assertEquals(formatted.text, "Hello\u00A0World");
+    assertEquals(formatted.entities.length, 0);
+  });
+
+  it("should decode decimal numeric entities", () => {
+    const formatted = FormattedString.fromHtml("&#72;&#101;&#108;&#108;&#111;");
+    assertEquals(formatted.text, "Hello");
+    assertEquals(formatted.entities.length, 0);
+  });
+
+  it("should decode hex numeric entities", () => {
+    const formatted = FormattedString.fromHtml(
+      "&#x48;&#x65;&#x6C;&#x6C;&#x6F;",
+    );
+    assertEquals(formatted.text, "Hello");
+    assertEquals(formatted.entities.length, 0);
+  });
+
+  it("should handle HTML entities in formatted text", () => {
+    const formatted = FormattedString.fromHtml("<b>&lt;bold&gt;</b>");
+    assertEquals(formatted.text, "<bold>");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "bold");
+    assertEquals(formatted.entities[0].offset, 0);
+    assertEquals(formatted.entities[0].length, 6);
+  });
+
+  it("should preserve unknown entities as literal text", () => {
+    const formatted = FormattedString.fromHtml("&unknown;");
+    assertEquals(formatted.text, "&unknown;");
+    assertEquals(formatted.entities.length, 0);
+  });
+});
+
+describe("FormattedString.fromHtml - Plain text", () => {
+  it("should handle plain text without tags", () => {
+    const formatted = FormattedString.fromHtml("Hello World");
+    assertEquals(formatted.text, "Hello World");
+    assertEquals(formatted.entities.length, 0);
+  });
+
+  it("should handle empty string", () => {
+    const formatted = FormattedString.fromHtml("");
+    assertEquals(formatted.text, "");
+    assertEquals(formatted.entities.length, 0);
+  });
+
+  it("should handle text with mixed content", () => {
+    const formatted = FormattedString.fromHtml(
+      "Start <b>bold</b> middle <i>italic</i> end",
+    );
+    assertEquals(formatted.text, "Start bold middle italic end");
+    assertEquals(formatted.entities.length, 2);
+    assertEquals(formatted.entities[0].type, "bold");
+    assertEquals(formatted.entities[0].offset, 6);
+    assertEquals(formatted.entities[0].length, 4);
+    assertEquals(formatted.entities[1].type, "italic");
+    assertEquals(formatted.entities[1].offset, 18);
+    assertEquals(formatted.entities[1].length, 6);
+  });
+});
+
+describe("FormattedString.fromHtml - Edge cases", () => {
+  it("should treat unknown tags as plain text", () => {
+    const formatted = FormattedString.fromHtml(
+      "<unknown>Hello</unknown> World",
+    );
+    assertEquals(formatted.text, "<unknown>Hello</unknown> World");
+    assertEquals(formatted.entities.length, 0);
+  });
+
+  it("should handle unclosed opening tags", () => {
+    const formatted = FormattedString.fromHtml("<b>Hello");
+    assertEquals(formatted.text, "Hello");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "bold");
+    assertEquals(formatted.entities[0].offset, 0);
+    assertEquals(formatted.entities[0].length, 5);
+  });
+
+  it("should handle unmatched closing tags", () => {
+    const formatted = FormattedString.fromHtml("Hello</b>World");
+    assertEquals(formatted.text, "HelloWorld");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "bold");
+    assertEquals(formatted.entities[0].offset, 5);
+    assertEquals(formatted.entities[0].length, 5);
+  });
+
+  it("should handle malformed tags with space after <", () => {
+    const formatted = FormattedString.fromHtml("< b>Hello</b>");
+    assertEquals(formatted.text, "< b>Hello");
+    assertEquals(formatted.entities.length, 0);
+  });
+
+  it("should handle empty tags <>", () => {
+    const formatted = FormattedString.fromHtml("Hello<>World");
+    assertEquals(formatted.text, "Hello<>World");
+    assertEquals(formatted.entities.length, 0);
+  });
+
+  it("should handle incomplete entity at end of string", () => {
+    const formatted = FormattedString.fromHtml("Hello &amp");
+    assertEquals(formatted.text, "Hello &amp");
+    assertEquals(formatted.entities.length, 0);
+  });
+
+  it("should handle incomplete tag at end of string", () => {
+    const formatted = FormattedString.fromHtml("Hello <b");
+    assertEquals(formatted.text, "Hello <b");
+    assertEquals(formatted.entities.length, 0);
+  });
+
+  it("should handle < followed by <", () => {
+    const formatted = FormattedString.fromHtml("<<b>test</b>");
+    assertEquals(formatted.text, "<test");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "bold");
+  });
+
+  it("should handle span without tg-spoiler class as plain text", () => {
+    const formatted = FormattedString.fromHtml(
+      '<span class="other">text</span>',
+    );
+    // Opening tag without proper class becomes plain text
+    // Closing </span> has no matching open, so no entity is created (0-length filtered)
+    assertEquals(formatted.text, '<span class="other">text');
+    assertEquals(formatted.entities.length, 0);
+  });
+
+  it("should handle <a> without href as plain text", () => {
+    const formatted = FormattedString.fromHtml("<a>no href</a>");
+    // Opening <a> without href becomes plain text
+    // Closing </a> has no matching open, so no entity is created (0-length filtered)
+    assertEquals(formatted.text, "<a>no href");
+    assertEquals(formatted.entities.length, 0);
+  });
+
+  it("should handle <tg-emoji> without emoji-id as plain text", () => {
+    const formatted = FormattedString.fromHtml("<tg-emoji>👍</tg-emoji>");
+    // Opening tag without emoji-id becomes plain text
+    // Closing tag has no matching open, so no entity is created (0-length filtered)
+    assertEquals(formatted.text, "<tg-emoji>👍");
+    assertEquals(formatted.entities.length, 0);
+  });
+
+  it("should handle user mention links", () => {
+    const formatted = FormattedString.fromHtml(
+      '<a href="tg://user?id=123456">User</a>',
+    );
+    assertEquals(formatted.text, "User");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "text_link");
+    // @ts-expect-error accessing url property
+    assertEquals(formatted.entities[0].url, "tg://user?id=123456");
+  });
+
+  it("should handle single quotes in attribute values", () => {
+    const formatted = FormattedString.fromHtml(
+      "<a href='https://example.com'>link</a>",
+    );
+    assertEquals(formatted.text, "link");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "text_link");
+    // @ts-expect-error accessing url property
+    assertEquals(formatted.entities[0].url, "https://example.com");
+  });
+
+  it("should handle case insensitive tag names", () => {
+    const formatted = FormattedString.fromHtml("<B>Bold</B> <I>Italic</I>");
+    assertEquals(formatted.text, "Bold Italic");
+    assertEquals(formatted.entities.length, 2);
+    assertEquals(formatted.entities[0].type, "bold");
+    assertEquals(formatted.entities[1].type, "italic");
+  });
+});
+
+describe("FormattedString - fromHtml instance method", () => {
+  it("should combine existing FormattedString with parsed HTML", () => {
+    const initial = new FormattedString("Hello ");
+    const combined = initial.fromHtml("<b>world</b>!");
+
+    assertEquals(combined.text, "Hello world!");
+    assertEquals(combined.entities.length, 1);
+    assertEquals(combined.entities[0].type, "bold");
+    assertEquals(combined.entities[0].offset, 6);
+    assertEquals(combined.entities[0].length, 5);
+  });
+
+  it("should preserve existing entities when appending HTML", () => {
+    const initial = FormattedString.bold("Hello");
+    const combined = initial.fromHtml(" <i>world</i>");
+
+    assertEquals(combined.text, "Hello world");
+    assertEquals(combined.entities.length, 2);
+    assertEquals(combined.entities[0].type, "bold");
+    assertEquals(combined.entities[0].offset, 0);
+    assertEquals(combined.entities[0].length, 5);
+    assertEquals(combined.entities[1].type, "italic");
+    assertEquals(combined.entities[1].offset, 6);
+    assertEquals(combined.entities[1].length, 5);
+  });
+
+  it("should handle multiple HTML appends", () => {
+    const initial = new FormattedString("Start ");
+    const step1 = initial.fromHtml("<b>bold</b> ");
+    const step2 = step1.fromHtml("<i>italic</i>");
+
+    assertEquals(step2.text, "Start bold italic");
+    assertEquals(step2.entities.length, 2);
+    assertEquals(step2.entities[0].type, "bold");
+    assertEquals(step2.entities[0].offset, 6);
+    assertEquals(step2.entities[0].length, 4);
+    assertEquals(step2.entities[1].type, "italic");
+    assertEquals(step2.entities[1].offset, 11);
+    assertEquals(step2.entities[1].length, 6);
+  });
+
+  it("should work with complex HTML", () => {
+    const initial = new FormattedString("Prefix: ");
+    const combined = initial.fromHtml(
+      '<a href="https://example.com">Link</a> with <code>code</code>',
+    );
+
+    assertEquals(combined.text, "Prefix: Link with code");
+    assertEquals(combined.entities.length, 2);
+    assertEquals(combined.entities[0].type, "text_link");
+    assertEquals(combined.entities[0].offset, 8);
+    assertEquals(combined.entities[0].length, 4);
+    assertEquals(combined.entities[1].type, "code");
+    assertEquals(combined.entities[1].offset, 18);
+    assertEquals(combined.entities[1].length, 4);
+  });
+
+  it("should handle empty HTML string", () => {
+    const initial = new FormattedString("Hello");
+    const combined = initial.fromHtml("");
+
+    assertEquals(combined.text, "Hello");
+    assertEquals(combined.entities.length, 0);
+  });
+
+  it("should handle plain text HTML", () => {
+    const initial = new FormattedString("Hello ");
+    const combined = initial.fromHtml("world");
+
+    assertEquals(combined.text, "Hello world");
+    assertEquals(combined.entities.length, 0);
+  });
+
+  it("should work with nested HTML tags", () => {
+    const initial = new FormattedString("Text: ");
+    const combined = initial.fromHtml("<b>Bold <i>and italic</i></b>");
+
+    assertEquals(combined.text, "Text: Bold and italic");
+    assertEquals(combined.entities.length, 2);
+    assertEquals(combined.entities[0].type, "bold");
+    assertEquals(combined.entities[0].offset, 6);
+    assertEquals(combined.entities[0].length, 15);
+    assertEquals(combined.entities[1].type, "italic");
+    assertEquals(combined.entities[1].offset, 11);
+    assertEquals(combined.entities[1].length, 10);
+  });
+
+  it("should chain with other instance methods", () => {
+    const result = new FormattedString("Start ")
+      .fromHtml("<b>bold</b> ")
+      .italic("italic");
+
+    assertEquals(result.text, "Start bold italic");
+    assertEquals(result.entities.length, 2);
+    assertEquals(result.entities[0].type, "bold");
+    assertEquals(result.entities[0].offset, 6);
+    assertEquals(result.entities[0].length, 4);
+    assertEquals(result.entities[1].type, "italic");
+    assertEquals(result.entities[1].offset, 11);
+    assertEquals(result.entities[1].length, 6);
+  });
+});
+
+describe("FormattedString.fromHtml - Attribute parsing", () => {
+  it("should handle unquoted attribute values", () => {
+    const formatted = FormattedString.fromHtml(
+      "<a href=https://example.com>link</a>",
+    );
+    assertEquals(formatted.text, "link");
+    assertEquals(formatted.entities.length, 1);
+    // @ts-expect-error accessing url property
+    assertEquals(formatted.entities[0].url, "https://example.com");
+  });
+
+  it("should handle multiple attributes", () => {
+    const formatted = FormattedString.fromHtml(
+      '<pre language="python" class="code">print()</pre>',
+    );
+    assertEquals(formatted.text, "print()");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "pre");
+    // @ts-expect-error accessing language property
+    assertEquals(formatted.entities[0].language, "python");
+  });
+
+  it("should handle boolean attributes", () => {
+    const formatted = FormattedString.fromHtml(
+      "<blockquote expandable>quote</blockquote>",
+    );
+    assertEquals(formatted.text, "quote");
+    assertEquals(formatted.entities.length, 1);
+    assertEquals(formatted.entities[0].type, "expandable_blockquote");
+  });
+
+  it("should handle attributes with equals in value", () => {
+    // Note: HTML entities in attribute values are not decoded
+    // This matches browser behavior where attribute values are literal
+    const formatted = FormattedString.fromHtml(
+      '<a href="https://example.com?a=1&amp;b=2">link</a>',
+    );
+    assertEquals(formatted.text, "link");
+    assertEquals(formatted.entities.length, 1);
+    // @ts-expect-error accessing url property
+    assertEquals(formatted.entities[0].url, "https://example.com?a=1&amp;b=2");
+  });
+});


### PR DESCRIPTION
Implement a character-streaming FSM HTML parser that converts Telegram Bot API HTML-style formatted text into FormattedString.

Features:
- Static method: FormattedString.fromHtml(html)
- Instance method: formattedString.fromHtml(html)
- Supports all Telegram HTML formatting tags:
  - Bold: <b>, <strong>
  - Italic: <i>, <em>
  - Underline: <u>, <ins>
  - Strikethrough: <s>, <strike>, <del>
  - Spoiler: <tg-spoiler>, <span class="tg-spoiler">
  - Code: <code>
  - Pre: <pre>, <pre language="...">
  - Link: <a href="...">
  - Custom emoji: <tg-emoji emoji-id="...">
  - Blockquote: <blockquote>, <blockquote expandable>
- Decodes HTML entities: &lt;, &gt;, &amp;, &quot;, &apos;, &nbsp;
- Supports numeric entities: &#NN; and &#xHH;
- Handles nested tags and mixed content
- Gracefully handles malformed HTML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * FormattedString now accepts HTML-formatted text and converts it to formatted strings with support for bold, italic, underline, strikethrough, links, code blocks, spoilers, blockquotes, and custom emoji.

* **Tests**
  * Added comprehensive test coverage for HTML formatting functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->