### PR TITLE
feat: add FSM HTML parser with fromHtml methods

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -19,6 +19,7 @@ import {
   u,
   underline,
 } from "./entity-tag.ts";
+import { parseHtml } from "./html-parser.ts";
 import { consolidateEntities, isEntitiesEqual } from "./util.ts";
 
 /**
@@ -551,6 +552,28 @@ export class FormattedString
     return FormattedString._split(text, separator, true);
   }
 
+  /**
+   * Parses Telegram Bot API HTML into a FormattedString.
+   * Uses a character-streaming FSM parser for efficient parsing.
+   *
+   * Supported tags: b, strong, i, em, u, ins, s, strike, del, code, pre,
+   * span.tg-spoiler, tg-spoiler, tg-emoji, a, blockquote
+   *
+   * @param html The HTML string to parse
+   * @returns A new FormattedString with the parsed text and entities
+   *
+   * @example
+   * ```typescript
+   * const formatted = FormattedString.fromHtml("<b>bold</b> and <i>italic</i>");
+   * // formatted.text === "bold and italic"
+   * // formatted.entities includes bold and italic entities
+   * ```
+   */
+  static fromHtml(html: string): FormattedString {
+    const { text, entities } = parseHtml(html);
+    return new FormattedString(text, consolidateEntities(entities));
+  }
+
   // Instance formatting methods
   /**
    * Combines this FormattedString with a bold formatted string
@@ -739,6 +762,24 @@ export class FormattedString
    */
   plain(text: string) {
     return fmt`${this}${text}`;
+  }
+
+  /**
+   * Parses Telegram Bot API HTML and appends it to this FormattedString.
+   * Uses a character-streaming FSM parser for efficient parsing.
+   *
+   * @param html The HTML string to parse and append
+   * @returns A new FormattedString combining this instance with the parsed HTML
+   *
+   * @example
+   * ```typescript
+   * const prefix = new FormattedString("Prefix: ");
+   * const result = prefix.fromHtml("<b>bold</b>");
+   * // result.text === "Prefix: bold"
+   * ```
+   */
+  fromHtml(html: string): FormattedString {
+    return fmt`${this}${FormattedString.fromHtml(html)}`;
   }
 
   /**

--- a/src/html-parser.ts
+++ b/src/html-parser.ts
@@ -1,0 +1,400 @@
+import type { MessageEntity } from "./deps.deno.ts";
+
+/**
+ * FSM states for the HTML parser
+ */
+const enum State {
+  TEXT,
+  TAG_OPEN,
+  TAG_NAME,
+  CLOSE_TAG_NAME,
+  ATTR_SPACE,
+  ATTR_NAME,
+  ATTR_VALUE_START,
+  ATTR_VALUE,
+  ENTITY,
+}
+
+/**
+ * Maps HTML tag names to MessageEntity types
+ */
+const TAG_TO_ENTITY_TYPE: Record<string, MessageEntity["type"] | undefined> = {
+  b: "bold",
+  strong: "bold",
+  i: "italic",
+  em: "italic",
+  u: "underline",
+  ins: "underline",
+  s: "strikethrough",
+  strike: "strikethrough",
+  del: "strikethrough",
+  code: "code",
+  pre: "pre",
+  blockquote: "blockquote",
+  span: undefined, // needs class="tg-spoiler"
+  "tg-spoiler": "spoiler",
+  "tg-emoji": "custom_emoji",
+  a: "text_link",
+};
+
+/**
+ * Named HTML entities
+ */
+const NAMED_ENTITIES: Record<string, string> = {
+  lt: "<",
+  gt: ">",
+  amp: "&",
+  quot: '"',
+  apos: "'",
+  nbsp: "\u00A0",
+  copy: "\u00A9",
+  reg: "\u00AE",
+  trade: "\u2122",
+  euro: "\u20AC",
+  pound: "\u00A3",
+  yen: "\u00A5",
+  cent: "\u00A2",
+  mdash: "\u2014",
+  ndash: "\u2013",
+  hellip: "\u2026",
+  laquo: "\u00AB",
+  raquo: "\u00BB",
+  lsquo: "\u2018",
+  rsquo: "\u2019",
+  ldquo: "\u201C",
+  rdquo: "\u201D",
+  bull: "\u2022",
+  middot: "\u00B7",
+  deg: "\u00B0",
+  plusmn: "\u00B1",
+  times: "\u00D7",
+  divide: "\u00F7",
+  frac12: "\u00BD",
+  frac14: "\u00BC",
+  frac34: "\u00BE",
+};
+
+/**
+ * Tag stack entry for tracking open tags
+ */
+interface TagStackEntry {
+  tag: string;
+  entityType: MessageEntity["type"];
+  offset: number;
+  attrs: Record<string, string>;
+}
+
+/**
+ * Decodes an HTML entity string (without & and ;)
+ */
+function decodeEntity(entity: string): string {
+  if (entity.startsWith("#x") || entity.startsWith("#X")) {
+    const code = parseInt(entity.slice(2), 16);
+    return isNaN(code) ? `&${entity};` : String.fromCodePoint(code);
+  }
+  if (entity.startsWith("#")) {
+    const code = parseInt(entity.slice(1), 10);
+    return isNaN(code) ? `&${entity};` : String.fromCodePoint(code);
+  }
+  return NAMED_ENTITIES[entity] ?? `&${entity};`;
+}
+
+/**
+ * Parses Telegram Bot API HTML into plain text and MessageEntity array.
+ * Uses a character-streaming FSM approach to minimize regex and O(n) operations.
+ *
+ * @param html The HTML string to parse
+ * @returns Object with text (plain text) and entities (MessageEntity array)
+ */
+export function parseHtml(
+  html: string,
+): { text: string; entities: MessageEntity[] } {
+  let state: State = State.TEXT;
+  let output = "";
+  const entities: MessageEntity[] = [];
+  const tagStack: TagStackEntry[] = [];
+
+  let currentTag = "";
+  let currentAttrName = "";
+  let currentAttrValue = "";
+  let attrQuoteChar = "";
+  let currentAttrs: Record<string, string> = {};
+  let entityBuffer = "";
+
+  for (let i = 0; i < html.length; i++) {
+    const char = html[i];
+
+    switch (state) {
+      case State.TEXT:
+        if (char === "<") {
+          state = State.TAG_OPEN;
+          currentTag = "";
+          currentAttrs = {};
+        } else if (char === "&") {
+          state = State.ENTITY;
+          entityBuffer = "";
+        } else {
+          output += char;
+        }
+        break;
+
+      case State.TAG_OPEN:
+        if (char === "/") {
+          state = State.CLOSE_TAG_NAME;
+        } else if (
+          char === ">" || char === " " || char === "\t" || char === "\n" ||
+          char === "\r"
+        ) {
+          // Empty tag like "<>" - treat as text
+          output += "<" + char;
+          state = State.TEXT;
+        } else {
+          currentTag = char.toLowerCase();
+          state = State.TAG_NAME;
+        }
+        break;
+
+      case State.TAG_NAME:
+        if (char === ">") {
+          handleOpenTag(currentTag, currentAttrs, output.length, tagStack);
+          state = State.TEXT;
+        } else if (
+          char === " " || char === "\t" || char === "\n" || char === "\r"
+        ) {
+          state = State.ATTR_SPACE;
+        } else if (char === "/") {
+          // Self-closing tag start, wait for >
+        } else {
+          currentTag += char.toLowerCase();
+        }
+        break;
+
+      case State.CLOSE_TAG_NAME:
+        if (char === ">") {
+          handleCloseTag(currentTag, output.length, tagStack, entities);
+          state = State.TEXT;
+        } else if (
+          char !== " " && char !== "\t" && char !== "\n" && char !== "\r"
+        ) {
+          currentTag += char.toLowerCase();
+        }
+        break;
+
+      case State.ATTR_SPACE:
+        if (char === ">") {
+          handleOpenTag(currentTag, currentAttrs, output.length, tagStack);
+          state = State.TEXT;
+        } else if (char === "/") {
+          // Self-closing tag marker
+        } else if (
+          char !== " " && char !== "\t" && char !== "\n" && char !== "\r"
+        ) {
+          currentAttrName = char.toLowerCase();
+          state = State.ATTR_NAME;
+        }
+        break;
+
+      case State.ATTR_NAME:
+        if (char === "=") {
+          state = State.ATTR_VALUE_START;
+        } else if (char === ">") {
+          // Boolean attribute
+          currentAttrs[currentAttrName] = "";
+          handleOpenTag(currentTag, currentAttrs, output.length, tagStack);
+          state = State.TEXT;
+        } else if (
+          char === " " || char === "\t" || char === "\n" || char === "\r"
+        ) {
+          // Boolean attribute, look for next attr or end
+          currentAttrs[currentAttrName] = "";
+          state = State.ATTR_SPACE;
+        } else if (char === "/") {
+          // Self-closing with boolean attr
+          currentAttrs[currentAttrName] = "";
+        } else {
+          currentAttrName += char.toLowerCase();
+        }
+        break;
+
+      case State.ATTR_VALUE_START:
+        if (char === '"' || char === "'") {
+          attrQuoteChar = char;
+          currentAttrValue = "";
+          state = State.ATTR_VALUE;
+        } else if (char === ">") {
+          // Empty attribute value
+          currentAttrs[currentAttrName] = "";
+          handleOpenTag(currentTag, currentAttrs, output.length, tagStack);
+          state = State.TEXT;
+        } else if (
+          char !== " " && char !== "\t" && char !== "\n" && char !== "\r"
+        ) {
+          // Unquoted attribute value
+          currentAttrValue = char;
+          attrQuoteChar = "";
+          state = State.ATTR_VALUE;
+        }
+        break;
+
+      case State.ATTR_VALUE:
+        if (attrQuoteChar && char === attrQuoteChar) {
+          currentAttrs[currentAttrName] = currentAttrValue;
+          state = State.ATTR_SPACE;
+        } else if (
+          !attrQuoteChar &&
+          (char === " " || char === "\t" || char === "\n" || char === "\r")
+        ) {
+          currentAttrs[currentAttrName] = currentAttrValue;
+          state = State.ATTR_SPACE;
+        } else if (!attrQuoteChar && char === ">") {
+          currentAttrs[currentAttrName] = currentAttrValue;
+          handleOpenTag(currentTag, currentAttrs, output.length, tagStack);
+          state = State.TEXT;
+        } else {
+          currentAttrValue += char;
+        }
+        break;
+
+      case State.ENTITY:
+        if (char === ";") {
+          output += decodeEntity(entityBuffer);
+          state = State.TEXT;
+        } else if (char === "<") {
+          // Malformed entity, output as-is and process tag
+          output += "&" + entityBuffer;
+          state = State.TAG_OPEN;
+          currentTag = "";
+          currentAttrs = {};
+        } else if (char === "&") {
+          // Another & before ; - output previous and start new
+          output += "&" + entityBuffer;
+          entityBuffer = "";
+        } else if (
+          char === " " || char === "\t" || char === "\n" || char === "\r"
+        ) {
+          // Malformed entity, output as-is
+          output += "&" + entityBuffer + char;
+          state = State.TEXT;
+        } else {
+          entityBuffer += char;
+        }
+        break;
+    }
+  }
+
+  // Handle any unclosed state
+  if (state === State.ENTITY) {
+    output += "&" + entityBuffer;
+  } else if (state === State.TAG_OPEN) {
+    output += "<";
+  } else if (
+    state === State.TAG_NAME || state === State.ATTR_SPACE ||
+    state === State.ATTR_NAME ||
+    state === State.ATTR_VALUE_START || state === State.ATTR_VALUE
+  ) {
+    // Unclosed tag - discard it
+  } else if (state === State.CLOSE_TAG_NAME) {
+    // Unclosed closing tag - discard it
+  }
+
+  return { text: output, entities };
+}
+
+/**
+ * Handles an opening tag by pushing to the tag stack
+ */
+function handleOpenTag(
+  tag: string,
+  attrs: Record<string, string>,
+  offset: number,
+  tagStack: TagStackEntry[],
+): void {
+  let entityType = TAG_TO_ENTITY_TYPE[tag];
+
+  // Handle special cases
+  if (tag === "span") {
+    if (attrs["class"] === "tg-spoiler") {
+      entityType = "spoiler";
+    } else {
+      return; // Unsupported span, ignore
+    }
+  }
+
+  if (tag === "blockquote" && "expandable" in attrs) {
+    entityType = "expandable_blockquote";
+  }
+
+  if (!entityType) {
+    return; // Unsupported tag
+  }
+
+  // Handle <pre><code class="language-xxx"> pattern
+  // When we see a <code> inside a <pre>, update the pre's language
+  if (tag === "code" && tagStack.length > 0) {
+    const lastTag = tagStack[tagStack.length - 1];
+    if (lastTag.tag === "pre" && attrs["class"]?.startsWith("language-")) {
+      lastTag.attrs["language"] = attrs["class"].slice(9);
+      // Push code tag so it can be closed, but it won't create a separate entity
+      tagStack.push({ tag, entityType, offset, attrs: { insidePre: "true" } });
+      return;
+    }
+  }
+
+  tagStack.push({ tag, entityType, offset, attrs });
+}
+
+/**
+ * Handles a closing tag by popping from the tag stack and creating an entity
+ */
+function handleCloseTag(
+  tag: string,
+  offset: number,
+  tagStack: TagStackEntry[],
+  entities: MessageEntity[],
+): void {
+  // Find matching opening tag (search from end)
+  let matchIndex = -1;
+  for (let i = tagStack.length - 1; i >= 0; i--) {
+    if (tagStack[i].tag === tag) {
+      matchIndex = i;
+      break;
+    }
+  }
+
+  if (matchIndex === -1) {
+    return; // No matching opening tag
+  }
+
+  const entry = tagStack.splice(matchIndex, 1)[0];
+  const length = offset - entry.offset;
+
+  // Skip code tags that are inside pre
+  if (entry.attrs["insidePre"]) {
+    return;
+  }
+
+  // Don't create empty entities
+  if (length <= 0) {
+    return;
+  }
+
+  // Build the entity
+  const entity: MessageEntity = {
+    type: entry.entityType,
+    offset: entry.offset,
+    length,
+  } as MessageEntity;
+
+  // Add type-specific properties
+  if (entry.entityType === "text_link" && entry.attrs["href"]) {
+    (entity as MessageEntity & { url: string }).url = entry.attrs["href"];
+  } else if (entry.entityType === "pre" && entry.attrs["language"]) {
+    (entity as MessageEntity & { language: string }).language =
+      entry.attrs["language"];
+  } else if (entry.entityType === "custom_emoji" && entry.attrs["emoji-id"]) {
+    (entity as MessageEntity & { custom_emoji_id: string }).custom_emoji_id =
+      entry.attrs["emoji-id"];
+  }
+
+  entities.push(entity);
+}

--- a/test/format.fromHtml.test.ts
+++ b/test/format.fromHtml.test.ts
@@ -1,0 +1,368 @@
+import { assertEquals, assertInstanceOf, describe, it } from "./deps.test.ts";
+import { FormattedString } from "../src/format.ts";
+
+describe("FormattedString - fromHtml", () => {
+  describe("Static method", () => {
+    it("should parse plain text without tags", () => {
+      const result = FormattedString.fromHtml("Hello World");
+      assertInstanceOf(result, FormattedString);
+      assertEquals(result.rawText, "Hello World");
+      assertEquals(result.rawEntities, []);
+    });
+
+    it("should parse empty string", () => {
+      const result = FormattedString.fromHtml("");
+      assertEquals(result.rawText, "");
+      assertEquals(result.rawEntities, []);
+    });
+
+    describe("Bold formatting", () => {
+      it("should parse <b> tag", () => {
+        const result = FormattedString.fromHtml("<b>bold text</b>");
+        assertEquals(result.rawText, "bold text");
+        assertEquals(result.rawEntities.length, 1);
+        assertEquals(result.rawEntities[0]?.type, "bold");
+        assertEquals(result.rawEntities[0]?.offset, 0);
+        assertEquals(result.rawEntities[0]?.length, 9);
+      });
+
+      it("should parse <strong> tag", () => {
+        const result = FormattedString.fromHtml("<strong>bold text</strong>");
+        assertEquals(result.rawText, "bold text");
+        assertEquals(result.rawEntities.length, 1);
+        assertEquals(result.rawEntities[0]?.type, "bold");
+      });
+    });
+
+    describe("Italic formatting", () => {
+      it("should parse <i> tag", () => {
+        const result = FormattedString.fromHtml("<i>italic text</i>");
+        assertEquals(result.rawText, "italic text");
+        assertEquals(result.rawEntities.length, 1);
+        assertEquals(result.rawEntities[0]?.type, "italic");
+        assertEquals(result.rawEntities[0]?.offset, 0);
+        assertEquals(result.rawEntities[0]?.length, 11);
+      });
+
+      it("should parse <em> tag", () => {
+        const result = FormattedString.fromHtml("<em>italic text</em>");
+        assertEquals(result.rawText, "italic text");
+        assertEquals(result.rawEntities.length, 1);
+        assertEquals(result.rawEntities[0]?.type, "italic");
+      });
+    });
+
+    describe("Underline formatting", () => {
+      it("should parse <u> tag", () => {
+        const result = FormattedString.fromHtml("<u>underline text</u>");
+        assertEquals(result.rawText, "underline text");
+        assertEquals(result.rawEntities.length, 1);
+        assertEquals(result.rawEntities[0]?.type, "underline");
+      });
+
+      it("should parse <ins> tag", () => {
+        const result = FormattedString.fromHtml("<ins>underline text</ins>");
+        assertEquals(result.rawText, "underline text");
+        assertEquals(result.rawEntities[0]?.type, "underline");
+      });
+    });
+
+    describe("Strikethrough formatting", () => {
+      it("should parse <s> tag", () => {
+        const result = FormattedString.fromHtml("<s>strikethrough</s>");
+        assertEquals(result.rawText, "strikethrough");
+        assertEquals(result.rawEntities[0]?.type, "strikethrough");
+      });
+
+      it("should parse <strike> tag", () => {
+        const result = FormattedString.fromHtml(
+          "<strike>strikethrough</strike>",
+        );
+        assertEquals(result.rawText, "strikethrough");
+        assertEquals(result.rawEntities[0]?.type, "strikethrough");
+      });
+
+      it("should parse <del> tag", () => {
+        const result = FormattedString.fromHtml("<del>strikethrough</del>");
+        assertEquals(result.rawText, "strikethrough");
+        assertEquals(result.rawEntities[0]?.type, "strikethrough");
+      });
+    });
+
+    describe("Spoiler formatting", () => {
+      it("should parse <tg-spoiler> tag", () => {
+        const result = FormattedString.fromHtml(
+          "<tg-spoiler>spoiler text</tg-spoiler>",
+        );
+        assertEquals(result.rawText, "spoiler text");
+        assertEquals(result.rawEntities.length, 1);
+        assertEquals(result.rawEntities[0]?.type, "spoiler");
+      });
+
+      it('should parse <span class="tg-spoiler"> tag', () => {
+        const result = FormattedString.fromHtml(
+          '<span class="tg-spoiler">spoiler text</span>',
+        );
+        assertEquals(result.rawText, "spoiler text");
+        assertEquals(result.rawEntities.length, 1);
+        assertEquals(result.rawEntities[0]?.type, "spoiler");
+      });
+
+      it("should ignore span without tg-spoiler class", () => {
+        const result = FormattedString.fromHtml(
+          '<span class="other">text</span>',
+        );
+        assertEquals(result.rawText, "text");
+        assertEquals(result.rawEntities, []);
+      });
+    });
+
+    describe("Code formatting", () => {
+      it("should parse <code> tag", () => {
+        const result = FormattedString.fromHtml("<code>inline code</code>");
+        assertEquals(result.rawText, "inline code");
+        assertEquals(result.rawEntities.length, 1);
+        assertEquals(result.rawEntities[0]?.type, "code");
+      });
+    });
+
+    describe("Pre formatting", () => {
+      it("should parse <pre> tag without language", () => {
+        const result = FormattedString.fromHtml("<pre>code block</pre>");
+        assertEquals(result.rawText, "code block");
+        assertEquals(result.rawEntities.length, 1);
+        assertEquals(result.rawEntities[0]?.type, "pre");
+      });
+
+      it('should parse <pre><code class="language-xxx"> pattern', () => {
+        const result = FormattedString.fromHtml(
+          '<pre><code class="language-python">print("Hello")</code></pre>',
+        );
+        assertEquals(result.rawText, 'print("Hello")');
+        assertEquals(result.rawEntities.length, 1);
+        assertEquals(result.rawEntities[0]?.type, "pre");
+        assertEquals(
+          (result.rawEntities[0] as { language?: string })?.language,
+          "python",
+        );
+      });
+    });
+
+    describe("Link formatting", () => {
+      it('should parse <a href="url"> tag', () => {
+        const result = FormattedString.fromHtml(
+          '<a href="https://example.com">link text</a>',
+        );
+        assertEquals(result.rawText, "link text");
+        assertEquals(result.rawEntities.length, 1);
+        assertEquals(result.rawEntities[0]?.type, "text_link");
+        assertEquals(
+          (result.rawEntities[0] as { url?: string })?.url,
+          "https://example.com",
+        );
+      });
+
+      it("should parse user mention link", () => {
+        const result = FormattedString.fromHtml(
+          '<a href="tg://user?id=123456">user name</a>',
+        );
+        assertEquals(result.rawText, "user name");
+        assertEquals(result.rawEntities[0]?.type, "text_link");
+        assertEquals(
+          (result.rawEntities[0] as { url?: string })?.url,
+          "tg://user?id=123456",
+        );
+      });
+    });
+
+    describe("Custom emoji formatting", () => {
+      it('should parse <tg-emoji emoji-id="xxx"> tag', () => {
+        const result = FormattedString.fromHtml(
+          '<tg-emoji emoji-id="5368324170671202286">👍</tg-emoji>',
+        );
+        assertEquals(result.rawText, "👍");
+        assertEquals(result.rawEntities.length, 1);
+        assertEquals(result.rawEntities[0]?.type, "custom_emoji");
+        assertEquals(
+          (result.rawEntities[0] as { custom_emoji_id?: string })
+            ?.custom_emoji_id,
+          "5368324170671202286",
+        );
+      });
+    });
+
+    describe("Blockquote formatting", () => {
+      it("should parse <blockquote> tag", () => {
+        const result = FormattedString.fromHtml(
+          "<blockquote>quoted text</blockquote>",
+        );
+        assertEquals(result.rawText, "quoted text");
+        assertEquals(result.rawEntities.length, 1);
+        assertEquals(result.rawEntities[0]?.type, "blockquote");
+      });
+
+      it("should parse <blockquote expandable> tag", () => {
+        const result = FormattedString.fromHtml(
+          "<blockquote expandable>expandable text</blockquote>",
+        );
+        assertEquals(result.rawText, "expandable text");
+        assertEquals(result.rawEntities.length, 1);
+        assertEquals(result.rawEntities[0]?.type, "expandable_blockquote");
+      });
+    });
+
+    describe("Nested formatting", () => {
+      it("should parse nested bold and italic", () => {
+        const result = FormattedString.fromHtml("<b><i>bold italic</i></b>");
+        assertEquals(result.rawText, "bold italic");
+        assertEquals(result.rawEntities.length, 2);
+        // Both entities should cover the same text
+        const types = result.rawEntities.map((e) => e.type).sort();
+        assertEquals(types, ["bold", "italic"]);
+      });
+
+      it("should parse adjacent formatting", () => {
+        const result = FormattedString.fromHtml(
+          "<b>bold</b> and <i>italic</i>",
+        );
+        assertEquals(result.rawText, "bold and italic");
+        assertEquals(result.rawEntities.length, 2);
+        assertEquals(result.rawEntities[0]?.type, "bold");
+        assertEquals(result.rawEntities[0]?.offset, 0);
+        assertEquals(result.rawEntities[0]?.length, 4);
+        assertEquals(result.rawEntities[1]?.type, "italic");
+        assertEquals(result.rawEntities[1]?.offset, 9);
+        assertEquals(result.rawEntities[1]?.length, 6);
+      });
+
+      it("should handle deeply nested tags", () => {
+        const result = FormattedString.fromHtml(
+          "<b><i><u>nested</u></i></b>",
+        );
+        assertEquals(result.rawText, "nested");
+        assertEquals(result.rawEntities.length, 3);
+      });
+    });
+
+    describe("HTML entities", () => {
+      it("should decode &lt; &gt; &amp;", () => {
+        const result = FormattedString.fromHtml("&lt;tag&gt; &amp; more");
+        assertEquals(result.rawText, "<tag> & more");
+      });
+
+      it("should decode numeric entities", () => {
+        const result = FormattedString.fromHtml("&#65;&#66;&#67;");
+        assertEquals(result.rawText, "ABC");
+      });
+
+      it("should decode hex numeric entities", () => {
+        const result = FormattedString.fromHtml("&#x41;&#x42;&#x43;");
+        assertEquals(result.rawText, "ABC");
+      });
+
+      it("should decode named entities", () => {
+        const result = FormattedString.fromHtml(
+          "&quot;hello&quot; &apos;world&apos;",
+        );
+        assertEquals(result.rawText, "\"hello\" 'world'");
+      });
+
+      it("should preserve unknown entities as-is", () => {
+        const result = FormattedString.fromHtml("&unknown;");
+        assertEquals(result.rawText, "&unknown;");
+      });
+
+      it("should handle malformed entities", () => {
+        const result = FormattedString.fromHtml("&lt no semicolon");
+        assertEquals(result.rawText, "&lt no semicolon");
+      });
+    });
+
+    describe("Edge cases", () => {
+      it("should handle empty tags", () => {
+        const result = FormattedString.fromHtml("<b></b>");
+        assertEquals(result.rawText, "");
+        assertEquals(result.rawEntities, []);
+      });
+
+      it("should handle unclosed tags", () => {
+        const result = FormattedString.fromHtml("<b>unclosed");
+        assertEquals(result.rawText, "unclosed");
+        assertEquals(result.rawEntities, []);
+      });
+
+      it("should handle unmatched closing tags", () => {
+        const result = FormattedString.fromHtml("text</b>");
+        assertEquals(result.rawText, "text");
+        assertEquals(result.rawEntities, []);
+      });
+
+      it("should handle mixed case tags", () => {
+        const result = FormattedString.fromHtml("<B>bold</B>");
+        assertEquals(result.rawText, "bold");
+        assertEquals(result.rawEntities.length, 1);
+        assertEquals(result.rawEntities[0]?.type, "bold");
+      });
+
+      it("should ignore unsupported tags", () => {
+        const result = FormattedString.fromHtml("<div>text</div>");
+        assertEquals(result.rawText, "text");
+        assertEquals(result.rawEntities, []);
+      });
+
+      it("should handle attributes with single quotes", () => {
+        const result = FormattedString.fromHtml(
+          "<a href='https://example.com'>link</a>",
+        );
+        assertEquals(result.rawText, "link");
+        assertEquals(
+          (result.rawEntities[0] as { url?: string })?.url,
+          "https://example.com",
+        );
+      });
+
+      it("should handle whitespace in tags", () => {
+        const result = FormattedString.fromHtml("<b  >text</b >");
+        assertEquals(result.rawText, "text");
+        assertEquals(result.rawEntities.length, 1);
+      });
+
+      it("should handle complex document", () => {
+        const html =
+          '<b>Hello</b> <i>world</i>! Check <a href="https://t.me">Telegram</a> &amp; more.';
+        const result = FormattedString.fromHtml(html);
+        assertEquals(result.rawText, "Hello world! Check Telegram & more.");
+        assertEquals(result.rawEntities.length, 3);
+      });
+    });
+  });
+
+  describe("Instance method", () => {
+    it("should append parsed HTML to existing FormattedString", () => {
+      const prefix = new FormattedString("Prefix: ");
+      const result = prefix.fromHtml("<b>bold</b>");
+      assertInstanceOf(result, FormattedString);
+      assertEquals(result.rawText, "Prefix: bold");
+      assertEquals(result.rawEntities.length, 1);
+      assertEquals(result.rawEntities[0]?.type, "bold");
+      assertEquals(result.rawEntities[0]?.offset, 8);
+      assertEquals(result.rawEntities[0]?.length, 4);
+    });
+
+    it("should preserve existing entities", () => {
+      const initial = FormattedString.bold("existing");
+      const result = initial.fromHtml(" <i>new</i>");
+      assertEquals(result.rawText, "existing new");
+      assertEquals(result.rawEntities.length, 2);
+      assertEquals(result.rawEntities[0]?.type, "bold");
+      assertEquals(result.rawEntities[1]?.type, "italic");
+    });
+
+    it("should work with empty prefix", () => {
+      const empty = new FormattedString("");
+      const result = empty.fromHtml("<b>text</b>");
+      assertEquals(result.rawText, "text");
+      assertEquals(result.rawEntities.length, 1);
+    });
+  });
+});

--- a/test/format.fromHtml.test.ts
+++ b/test/format.fromHtml.test.ts
@@ -276,6 +276,19 @@ describe("FormattedString - fromHtml", () => {
         const result = FormattedString.fromHtml("&lt no semicolon");
         assertEquals(result.rawText, "&lt no semicolon");
       });
+
+      it("should handle invalid code points gracefully", () => {
+        // Lone surrogates (0xD800-0xDFFF) are invalid code points
+        const result1 = FormattedString.fromHtml("&#55296;"); // 0xD800
+        assertEquals(result1.rawText, "&#55296;");
+
+        const result2 = FormattedString.fromHtml("&#xD800;");
+        assertEquals(result2.rawText, "&#xD800;");
+
+        // Negative numbers
+        const result3 = FormattedString.fromHtml("&#-1;");
+        assertEquals(result3.rawText, "&#-1;");
+      });
     });
 
     describe("Edge cases", () => {


### PR DESCRIPTION
- Add src/html-parser.ts with character-streaming FSM parser
- Supports all Telegram Bot API HTML tags (b, i, u, s, code, pre, a, etc.)
- Handles HTML entities (named, numeric, hex)
- Add static FormattedString.fromHtml() method
- Add instance formattedString.fromHtml() method
- Comprehensive test coverage in test/format.fromHtml.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTML parsing to convert Telegram-compatible HTML into formatted strings with consolidated entities, including bold/italic/underline/strikethrough, code/pre (with language extraction), text links, spoilers, custom emoji, and blockquotes.
  * Instance method to append parsed HTML to an existing formatted string while preserving entities.

* **Tests**
  * Added comprehensive tests covering formatting variants, nesting, entity decoding, custom emoji, code languages, links, edge cases, and appending behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->