### PR TITLE
fix(stream-html): parse contiguous opening brackets before tags

### DIFF
--- a/src/stream-html-to-format.ts
+++ b/src/stream-html-to-format.ts
@@ -716,8 +716,9 @@ export class HTMLStreamParser {
     // which are case-insensitive
     this.workingBufferText = char.toLowerCase();
     if (!isSupportedTagPrefix(this.workingBufferText)) {
-      this.text += this.fullTagOrEntityBufferText;
+      this.text += "<";
       this.resetWorkState();
+      this.addCharInTextMode(char);
       return;
     }
 

--- a/test/stream-html-to-format.test.ts
+++ b/test/stream-html-to-format.test.ts
@@ -131,6 +131,20 @@ describe("HTMLStreamParser", () => {
     assertEquals(formatted.rawEntities[0]?.length, "spoiler & text".length);
   });
 
+  it("parses contiguous opening brackets as plain text plus tag", () => {
+    const parser = new HTMLStreamParser();
+    parser.add("<<b");
+    parser.add(">bold</b>");
+
+    const formatted = parser.toFormattedString();
+
+    assertEquals(formatted.rawText, "<bold");
+    assertEquals(formatted.rawEntities.length, 1);
+    assertEquals(formatted.rawEntities[0]?.type, "bold");
+    assertEquals(formatted.rawEntities[0]?.offset, 1);
+    assertEquals(formatted.rawEntities[0]?.length, "bold".length);
+  });
+
   it("toFormattedString is idempotent for unchanged parser state", () => {
     const parser = new HTMLStreamParser();
     parser.add("<i>ok</i>");


### PR DESCRIPTION
## Summary
- treat invalid tag-start fallback after '<' as a plain '<' only
- reprocess the current character so a second '<' can start a valid tag parse path
- add regression coverage for streamed input split as '<<b' and '>bold</b>'

Closes #17

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes parsing of contiguous '<' before tags in the HTML streaming parser. The first '<' is emitted as text and the next character is reprocessed so the second '<' starts the tag (fixes #17).

- **Bug Fixes**
  - Added a regression test for streamed input split as '<<b' and '>bold</b>'.

<sup>Written for commit 0b154d36cd047e8fb58999bc7e0798313f85536c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stream parser to correctly handle edge cases with consecutive opening brackets (e.g., `<<b`). Literal brackets that don't form valid HTML tags are now properly preserved as plain text, while subsequent valid tags are correctly identified and processed. This resolves parsing issues where malformed bracket sequences were previously being handled incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->