### PR TITLE
fix(stream-parser): flush previous < as plain text on contiguous opening brackets

### DIFF
--- a/src/stream-html-to-format.ts
+++ b/src/stream-html-to-format.ts
@@ -705,6 +705,15 @@ export class HTMLStreamParser {
   }
 
   private addCharInDecisionOpenTagNameOrCloseTagNameMode(char: string): void {
+    // If we encounter another `<`, the previous `<` was plain text.
+    // Flush it and restart tag detection with this new `<`.
+    if (char === "<") {
+      this.text += this.fullTagOrEntityBufferText;
+      this.fullTagOrEntityBufferText = char;
+      this.workingBufferText = "";
+      return;
+    }
+
     this.fullTagOrEntityBufferText += char;
 
     if (char === "/") {

--- a/test/stream-html-to-format.test.ts
+++ b/test/stream-html-to-format.test.ts
@@ -131,6 +131,20 @@ describe("HTMLStreamParser", () => {
     assertEquals(formatted.rawEntities[0]?.length, "spoiler & text".length);
   });
 
+  it("evaluates contiguous opening brackets as plain text", () => {
+    const parser = new HTMLStreamParser();
+    parser.add("<<b");
+    parser.add(">bold</b>");
+
+    const formatted = parser.toFormattedString();
+
+    assertEquals(formatted.rawText, "<bold");
+    assertEquals(formatted.rawEntities.length, 1);
+    assertEquals(formatted.rawEntities[0]?.type, "bold");
+    assertEquals(formatted.rawEntities[0]?.offset, 1);
+    assertEquals(formatted.rawEntities[0]?.length, 4);
+  });
+
   it("toFormattedString is idempotent for unchanged parser state", () => {
     const parser = new HTMLStreamParser();
     parser.add("<i>ok</i>");


### PR DESCRIPTION
## Summary

Fixes #17 — contiguous opening brackets (e.g. `<<b>bold</b>`) were incorrectly evaluated as plain text instead of treating only the leading `<` as plain text and the subsequent `<b>` as a valid tag.

## Root Cause

In `addCharInDecisionOpenTagNameOrCloseTagNameMode`, encountering a second `<` appended it to the buffer (`<<`), which then failed the supported tag prefix check and flushed both characters as plain text. This caused the valid tag that followed to also be treated as plain text.

## Fix

When a `<` is encountered in `DECISION_OPEN_TAG_NAME_OR_CLOSE_TAG_NAME` mode, the existing buffer (the previous `<`) is flushed as plain text, and tag detection restarts with the new `<`. This mirrors browser HTML parsing behavior where `<<b>bold</b>` produces `<` as text followed by a bold entity around `bold`.

## Test

Added a test case verifying that `<<b>bold</b>` produces `<bold` with a single bold entity at offset 1, length 4.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes parsing of contiguous opening brackets so `<<b>bold</b>` yields a literal `<` followed by a valid `<b>` tag. Previously the parser treated the entire sequence as plain text.

- **Bug Fixes**
  - In `DECISION_OPEN_TAG_NAME_OR_CLOSE_TAG_NAME` mode, encountering `<<` now flushes the first `<` as text and restarts tag detection at the second `<`.
  - Added a regression test for `<<b>bold</b>` expecting raw text `<bold` and a single `bold` entity at offset 1, length 4.

<sup>Written for commit 019f30e8fe618175245edf2bec3b6ba81283d95a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTML stream parser to properly handle consecutive opening brackets, treating extra brackets as plain text while maintaining correct tag detection and content parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->