### PR TITLE
fix(stream-parser): handle < as tag restart in OPEN_TAG_NAME, CLOSE_TAG_NAME, and CLOSE_TAG_SEEK_END modes

### DIFF
--- a/src/stream-html-to-format.ts
+++ b/src/stream-html-to-format.ts
@@ -467,6 +467,17 @@ export class HTMLStreamParser {
   }
 
   private addCharInCloseTagNameMode(char: string): void {
+    // If we encounter another `<`, the current partial close tag was plain text.
+    // Flush it and restart tag detection with this new `<`.
+    if (char === "<") {
+      this.text += this.fullTagOrEntityBufferText;
+      this.fullTagOrEntityBufferText = char;
+      this.workingBufferText = "";
+      this.mode =
+        HTML_STREAM_PARSER_MODE.DECISION_OPEN_TAG_NAME_OR_CLOSE_TAG_NAME;
+      return;
+    }
+
     this.fullTagOrEntityBufferText += char;
 
     const isWhitespaceChar = isWhitespace(char);
@@ -521,6 +532,35 @@ export class HTMLStreamParser {
   }
 
   private addCharInCloseTagSeekEndMode(char: string): void {
+    // If we encounter `<` while seeking `>` for close tag, the close tag
+    // is complete (browser behavior). Finalize it and restart tag detection.
+    if (char === "<") {
+      if (!this.workingTag) {
+        throw new Error(
+          `No working tag in ${HTML_STREAM_PARSER_MODE.CLOSE_TAG_SEEK_END} mode`,
+        );
+      }
+
+      const lastMatchingOpenTag = this.tagStacks.get(this.workingTag.name)
+        ?.pop();
+      if (lastMatchingOpenTag) {
+        const entity = this.buildEntityFromOpenTag(lastMatchingOpenTag);
+        if (entity) {
+          this.entities.push(entity);
+        }
+      } else {
+        this.text += this.fullTagOrEntityBufferText;
+      }
+      this.fullTagOrEntityBufferText = char;
+      this.workingBufferText = "";
+      this.workingAttributeName = "";
+      this.attributeValueQuoteChar = undefined;
+      this.workingTag = undefined;
+      this.mode =
+        HTML_STREAM_PARSER_MODE.DECISION_OPEN_TAG_NAME_OR_CLOSE_TAG_NAME;
+      return;
+    }
+
     this.fullTagOrEntityBufferText += char;
 
     // This case should never hold true unless there is a logic bug
@@ -550,6 +590,17 @@ export class HTMLStreamParser {
   }
 
   private addCharInOpenTagNameMode(char: string): void {
+    // If we encounter another `<`, the current partial open tag was plain text.
+    // Flush it and restart tag detection with this new `<`.
+    if (char === "<") {
+      this.text += this.fullTagOrEntityBufferText;
+      this.fullTagOrEntityBufferText = char;
+      this.workingBufferText = "";
+      this.mode =
+        HTML_STREAM_PARSER_MODE.DECISION_OPEN_TAG_NAME_OR_CLOSE_TAG_NAME;
+      return;
+    }
+
     this.fullTagOrEntityBufferText += char;
 
     const isWhitespaceChar = isWhitespace(char);

--- a/test/stream-html-to-format.test.ts
+++ b/test/stream-html-to-format.test.ts
@@ -145,6 +145,105 @@ describe("HTMLStreamParser", () => {
     assertEquals(formatted.rawEntities[0]?.length, 4);
   });
 
+  it("flushes partial open tag and restarts on <: <b<b>bold</b>", () => {
+    const parser = new HTMLStreamParser();
+    parser.add("<b<b>bold</b>");
+
+    const formatted = parser.toFormattedString();
+
+    assertEquals(formatted.rawText, "<bbold");
+    assertEquals(formatted.rawEntities.length, 1);
+    assertEquals(formatted.rawEntities[0]?.type, "bold");
+    assertEquals(formatted.rawEntities[0]?.offset, 2);
+    assertEquals(formatted.rawEntities[0]?.length, 4);
+  });
+
+  it("flushes partial open tag across stream boundary: <b then <b>bold</b>", () => {
+    const parser = new HTMLStreamParser();
+    parser.add("<b");
+    parser.add("<b>bold</b>");
+
+    const formatted = parser.toFormattedString();
+
+    assertEquals(formatted.rawText, "<bbold");
+    assertEquals(formatted.rawEntities.length, 1);
+    assertEquals(formatted.rawEntities[0]?.type, "bold");
+    assertEquals(formatted.rawEntities[0]?.offset, 2);
+    assertEquals(formatted.rawEntities[0]?.length, 4);
+  });
+
+  it("flushes partial open tag for different tags: <i<b>bold</b>", () => {
+    const parser = new HTMLStreamParser();
+    parser.add("<i<b>bold</b>");
+
+    const formatted = parser.toFormattedString();
+
+    assertEquals(formatted.rawText, "<ibold");
+    assertEquals(formatted.rawEntities.length, 1);
+    assertEquals(formatted.rawEntities[0]?.type, "bold");
+    assertEquals(formatted.rawEntities[0]?.offset, 2);
+    assertEquals(formatted.rawEntities[0]?.length, 4);
+  });
+
+  it("flushes partial close tag and restarts on <: <b>bold</</b>", () => {
+    const parser = new HTMLStreamParser();
+    parser.add("<b>bold</</b>");
+
+    const formatted = parser.toFormattedString();
+
+    assertEquals(formatted.rawText, "bold</");
+    assertEquals(formatted.rawEntities.length, 1);
+    assertEquals(formatted.rawEntities[0]?.type, "bold");
+    assertEquals(formatted.rawEntities[0]?.offset, 0);
+    assertEquals(formatted.rawEntities[0]?.length, 6);
+  });
+
+  it("flushes partial close tag mid-name: <b>bold</b<b>more</b>", () => {
+    const parser = new HTMLStreamParser();
+    parser.add("<b>bold</b<b>more</b>");
+
+    const formatted = parser.toFormattedString();
+
+    assertEquals(formatted.rawText, "bold</bmore");
+    assertEquals(formatted.rawEntities.length, 1);
+    assertEquals(formatted.rawEntities[0]?.type, "bold");
+    assertEquals(formatted.rawEntities[0]?.offset, 7);
+    assertEquals(formatted.rawEntities[0]?.length, 4);
+  });
+
+  it("finalizes close tag on < in seek-end mode: <b>text</b <b>more</b>", () => {
+    const parser = new HTMLStreamParser();
+    parser.add("<b>text</b <b>more</b>");
+
+    const formatted = parser.toFormattedString();
+
+    assertEquals(formatted.rawText, "textmore");
+    assertEquals(formatted.rawEntities.length, 2);
+    assertEquals(formatted.rawEntities[0]?.type, "bold");
+    assertEquals(formatted.rawEntities[0]?.offset, 0);
+    assertEquals(formatted.rawEntities[0]?.length, 4);
+    assertEquals(formatted.rawEntities[1]?.type, "bold");
+    assertEquals(formatted.rawEntities[1]?.offset, 4);
+    assertEquals(formatted.rawEntities[1]?.length, 4);
+  });
+
+  it("finalizes close tag on < across stream boundary in seek-end mode", () => {
+    const parser = new HTMLStreamParser();
+    parser.add("<b>text</b ");
+    parser.add("<i>more</i>");
+
+    const formatted = parser.toFormattedString();
+
+    assertEquals(formatted.rawText, "textmore");
+    assertEquals(formatted.rawEntities.length, 2);
+    assertEquals(formatted.rawEntities[0]?.type, "bold");
+    assertEquals(formatted.rawEntities[0]?.offset, 0);
+    assertEquals(formatted.rawEntities[0]?.length, 4);
+    assertEquals(formatted.rawEntities[1]?.type, "italic");
+    assertEquals(formatted.rawEntities[1]?.offset, 4);
+    assertEquals(formatted.rawEntities[1]?.length, 4);
+  });
+
   it("toFormattedString is idempotent for unchanged parser state", () => {
     const parser = new HTMLStreamParser();
     parser.add("<i>ok</i>");


### PR DESCRIPTION
## Summary

Extends the fix from #17 to three additional parser modes where an unexpected `<` character was incorrectly handled. In each case, the `<` was being flushed as plain text (or silently consumed) instead of restarting tag detection.

### Affected modes

| Mode | Example input | Before (broken) | After (fixed) |
|------|--------------|-----------------|---------------|
| `OPEN_TAG_NAME` | `<b<b>bold</b>` | `<b<b>bold</b>` (0 entities) | `<bbold` (1 bold entity) |
| `CLOSE_TAG_NAME` | `<b>bold</</b>` | `bold</</b>` (0 entities) | `bold</` (1 bold entity) |
| `CLOSE_TAG_SEEK_END` | `<b>text</b <b>more</b>` | `textmore</b>` (1 entity) | `textmore` (2 entities) |

### Changes

- **`addCharInOpenTagNameMode`**: Flush partial open tag buffer and restart tag detection when `<` encountered
- **`addCharInCloseTagNameMode`**: Flush partial close tag buffer and restart tag detection when `<` encountered
- **`addCharInCloseTagSeekEndMode`**: Finalize the current close tag (browser behavior) and restart tag detection when `<` encountered
- **7 new tests** covering all three modes, including streamed chunk boundaries

Closes #20

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the HTML stream parser to treat an unexpected "<" as the start of a new tag in three modes, matching browser behavior and preventing incorrect plain-text flushes. This restores correct entity detection for inputs like "<b<b>", "<b>bold</</b>", and "<b>text</b <b>more</b>".

- **Bug Fixes**
  - In `OPEN_TAG_NAME`: flush partial open tag and restart tag detection on "<".
  - In `CLOSE_TAG_NAME`: flush partial close tag and restart on "<".
  - In `CLOSE_TAG_SEEK_END`: finalize the close tag and restart on "<".
  - Added 7 tests, including cross-chunk cases, covering all three modes.

<sup>Written for commit 9cf9ab7820e4c28962a4dd02bff63b6f45350d17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced HTML stream parser to better handle incomplete or split tags across stream boundaries, improving content formatting reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->