### PR TITLE
fix(stream-parser): handle < as tag restart in OPEN_TAG_NAME and CLOSE_TAG_NAME modes

### DIFF
--- a/src/stream-html-to-format.ts
+++ b/src/stream-html-to-format.ts
@@ -467,6 +467,17 @@ export class HTMLStreamParser {
   }
 
   private addCharInCloseTagNameMode(char: string): void {
+    // If we encounter another `<`, the current partial close tag was plain text.
+    // Flush it and restart tag detection with this new `<`.
+    if (char === "<") {
+      this.text += this.fullTagOrEntityBufferText;
+      this.fullTagOrEntityBufferText = char;
+      this.workingBufferText = "";
+      this.mode =
+        HTML_STREAM_PARSER_MODE.DECISION_OPEN_TAG_NAME_OR_CLOSE_TAG_NAME;
+      return;
+    }
+
     this.fullTagOrEntityBufferText += char;
 
     const isWhitespaceChar = isWhitespace(char);
@@ -550,6 +561,17 @@ export class HTMLStreamParser {
   }
 
   private addCharInOpenTagNameMode(char: string): void {
+    // If we encounter another `<`, the current partial open tag was plain text.
+    // Flush it and restart tag detection with this new `<`.
+    if (char === "<") {
+      this.text += this.fullTagOrEntityBufferText;
+      this.fullTagOrEntityBufferText = char;
+      this.workingBufferText = "";
+      this.mode =
+        HTML_STREAM_PARSER_MODE.DECISION_OPEN_TAG_NAME_OR_CLOSE_TAG_NAME;
+      return;
+    }
+
     this.fullTagOrEntityBufferText += char;
 
     const isWhitespaceChar = isWhitespace(char);

--- a/test/stream-html-to-format.test.ts
+++ b/test/stream-html-to-format.test.ts
@@ -145,6 +145,72 @@ describe("HTMLStreamParser", () => {
     assertEquals(formatted.rawEntities[0]?.length, 4);
   });
 
+  it("flushes partial open tag and restarts on <: <b<b>bold</b>", () => {
+    const parser = new HTMLStreamParser();
+    parser.add("<b<b>bold</b>");
+
+    const formatted = parser.toFormattedString();
+
+    assertEquals(formatted.rawText, "<bbold");
+    assertEquals(formatted.rawEntities.length, 1);
+    assertEquals(formatted.rawEntities[0]?.type, "bold");
+    assertEquals(formatted.rawEntities[0]?.offset, 2);
+    assertEquals(formatted.rawEntities[0]?.length, 4);
+  });
+
+  it("flushes partial open tag across stream boundary: <b then <b>bold</b>", () => {
+    const parser = new HTMLStreamParser();
+    parser.add("<b");
+    parser.add("<b>bold</b>");
+
+    const formatted = parser.toFormattedString();
+
+    assertEquals(formatted.rawText, "<bbold");
+    assertEquals(formatted.rawEntities.length, 1);
+    assertEquals(formatted.rawEntities[0]?.type, "bold");
+    assertEquals(formatted.rawEntities[0]?.offset, 2);
+    assertEquals(formatted.rawEntities[0]?.length, 4);
+  });
+
+  it("flushes partial open tag for different tags: <i<b>bold</b>", () => {
+    const parser = new HTMLStreamParser();
+    parser.add("<i<b>bold</b>");
+
+    const formatted = parser.toFormattedString();
+
+    assertEquals(formatted.rawText, "<ibold");
+    assertEquals(formatted.rawEntities.length, 1);
+    assertEquals(formatted.rawEntities[0]?.type, "bold");
+    assertEquals(formatted.rawEntities[0]?.offset, 2);
+    assertEquals(formatted.rawEntities[0]?.length, 4);
+  });
+
+  it("flushes partial close tag and restarts on <: <b>bold</</b>", () => {
+    const parser = new HTMLStreamParser();
+    parser.add("<b>bold</</b>");
+
+    const formatted = parser.toFormattedString();
+
+    assertEquals(formatted.rawText, "bold</");
+    assertEquals(formatted.rawEntities.length, 1);
+    assertEquals(formatted.rawEntities[0]?.type, "bold");
+    assertEquals(formatted.rawEntities[0]?.offset, 0);
+    assertEquals(formatted.rawEntities[0]?.length, 6);
+  });
+
+  it("flushes partial close tag mid-name: <b>bold</b<b>more</b>", () => {
+    const parser = new HTMLStreamParser();
+    parser.add("<b>bold</b<b>more</b>");
+
+    const formatted = parser.toFormattedString();
+
+    assertEquals(formatted.rawText, "bold</bmore");
+    assertEquals(formatted.rawEntities.length, 1);
+    assertEquals(formatted.rawEntities[0]?.type, "bold");
+    assertEquals(formatted.rawEntities[0]?.offset, 7);
+    assertEquals(formatted.rawEntities[0]?.length, 4);
+  });
+
   it("toFormattedString is idempotent for unchanged parser state", () => {
     const parser = new HTMLStreamParser();
     parser.add("<i>ok</i>");


### PR DESCRIPTION
## Summary

Extends the fix from #17 to two additional parser modes where an unexpected `<` character was incorrectly flushed as plain text instead of restarting tag detection.

### Affected modes

| Mode | Example input | Before (broken) | After (fixed) |
|------|--------------|-----------------|---------------|
| `OPEN_TAG_NAME` | `<b<b>bold</b>` | `<b<b>bold</b>` (0 entities) | `<bbold` (1 bold entity) |
| `CLOSE_TAG_NAME` | `<b>bold</</b>` | `bold</</b>` (0 entities) | `bold</` (1 bold entity) |

### Changes

- **`addCharInOpenTagNameMode`**: Flush partial open tag buffer and restart tag detection when `<` encountered
- **`addCharInCloseTagNameMode`**: Flush partial close tag buffer and restart tag detection when `<` encountered
- **5 new tests** covering both modes, including streamed chunk boundaries

The `CLOSE_TAG_SEEK_END` case is deferred to #22.

Closes #20

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the HTML stream parser to treat an unexpected `<` inside tag names as a tag restart instead of plain text. This restores correct entity detection for inputs like `<b<b>bold</b>` and `<b>bold</</b>`. Closes #20.

- **Bug Fixes**
  - Updated `addCharInOpenTagNameMode` and `addCharInCloseTagNameMode` to flush the partial tag and restart tag detection when `<` is encountered.
  - Added 5 tests covering both modes and streamed chunk boundaries.
  - The `CLOSE_TAG_SEEK_END` case will be addressed in #22.

<sup>Written for commit b1d9669f0a63181855b0116e60fea338526fc95a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced HTML stream parser robustness. The parser now properly handles cases where incomplete HTML tags are interrupted by new tags. When such interruptions occur, the parser correctly flushes buffered partial tag text, resets its state, and restarts tag detection, preventing parsing errors and data loss from malformed tag sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->